### PR TITLE
feat: add easy strings module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Py_simple 🚀
 
-Making Python feel like plain English. 
+Making Python feel like plain English.
 
 Py_simple is a beginner-friendly Python wrapper package designed to help beginners and developers perform common tasks using simple, intuitive functions.
 
@@ -47,6 +47,38 @@ Features include:
 - Cleaner mathematical operations
 
 ---
+### 🔤 Easy Strings
+
+Handle common string operations using clear, beginner-friendly functions.
+
+Features include:
+
+- Removing repeated spaces
+- Converting text to `snake_case`
+- Converting text to `kebab-case`
+- Checking whether text is a palindrome
+
+Example:
+
+```python
+from py_simple.easy_strings import (
+    is_palindrome,
+    remove_extra_spaces,
+    to_kebab_case,
+    to_snake_case,
+)
+
+remove_extra_spaces("  hello   world  ")
+# "hello world"
+
+to_snake_case("Hello World")
+# "hello_world"
+
+to_kebab_case("Hello World")
+# "hello-world"
+
+is_palindrome("Never odd or even")
+# True
 
 ### 🔄 Easy Converter
 

--- a/py_simple_package/src/py_simple/easy_strings.py
+++ b/py_simple_package/src/py_simple/easy_strings.py
@@ -1,0 +1,62 @@
+"""Beginner-friendly helpers for common string operations."""
+
+import re
+
+
+def remove_extra_spaces(text: str) -> str:
+    """
+    Removes leading, trailing, and repeated spaces from text.
+
+    Example:
+        remove_extra_spaces("  hello   world  ")
+        "hello world"
+    """
+    return " ".join(text.split())
+
+
+def to_snake_case(text: str) -> str:
+    """
+    Converts text to snake_case.
+
+    Example:
+        to_snake_case("Hello World")
+        "hello_world"
+    """
+    cleaned_text = _separate_words(text)
+    return cleaned_text.lower().replace(" ", "_")
+
+
+def to_kebab_case(text: str) -> str:
+    """
+    Converts text to kebab-case.
+
+    Example:
+        to_kebab_case("Hello World")
+        "hello-world"
+    """
+    cleaned_text = _separate_words(text)
+    return cleaned_text.lower().replace(" ", "-")
+
+
+def is_palindrome(text: str) -> bool:
+    """
+    Returns True when text reads the same forwards and backwards.
+
+    Spaces, punctuation, and letter casing are ignored.
+
+    Example:
+        is_palindrome("Never odd or even")
+        True
+    """
+    cleaned_text = "".join(
+        character.lower() for character in text if character.isalnum()
+    )
+    return cleaned_text == cleaned_text[::-1]
+
+
+def _separate_words(text: str) -> str:
+    """Normalizes common word separators and separates camel-case words."""
+    text = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", text)
+    text = re.sub(r"[_\-]+", " ", text)
+    text = re.sub(r"[^\w\s]", " ", text)
+    return remove_extra_spaces(text)

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -1,0 +1,67 @@
+import pytest
+
+from py_simple.easy_strings import (
+    is_palindrome,
+    remove_extra_spaces,
+    to_kebab_case,
+    to_snake_case,
+)
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("  hello   world  ", "hello world"),
+        ("hello world", "hello world"),
+        ("", ""),
+        ("   ", ""),
+        ("hello\tworld\nagain", "hello world again"),
+    ],
+)
+def test_remove_extra_spaces(text, expected):
+    assert remove_extra_spaces(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("Hello World", "hello_world"),
+        ("hello-world", "hello_world"),
+        ("hello_world", "hello_world"),
+        ("helloWorld", "hello_world"),
+        ("  Multiple   Spaces  ", "multiple_spaces"),
+        ("Python 3 Basics", "python_3_basics"),
+    ],
+)
+def test_to_snake_case(text, expected):
+    assert to_snake_case(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("Hello World", "hello-world"),
+        ("hello_world", "hello-world"),
+        ("hello-world", "hello-world"),
+        ("helloWorld", "hello-world"),
+        ("  Multiple   Spaces  ", "multiple-spaces"),
+        ("Python 3 Basics", "python-3-basics"),
+    ],
+)
+def test_to_kebab_case(text, expected):
+    assert to_kebab_case(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("racecar", True),
+        ("RaceCar", True),
+        ("Never odd or even", True),
+        ("A man, a plan, a canal: Panama!", True),
+        ("hello", False),
+        ("", True),
+    ],
+)
+def test_is_palindrome(text, expected):
+    assert is_palindrome(text) is expected


### PR DESCRIPTION
## Summary

Adds a new beginner-friendly `easy_strings` module with common string helper functions.

## Changes

* Added `remove_extra_spaces()`
* Added `to_snake_case()`
* Added `to_kebab_case()`
* Added `is_palindrome()`
* Added docstrings and examples
* Added 23 tests
* Updated the README with usage examples

## Testing

* `python -m pytest tests/test_strings.py -v` — 23 passed
* `pre-commit run --files README.md py_simple_package/src/py_simple/easy_strings.py tests/test_strings.py` — all hooks passed

The full test suite also reported 208 passing tests, with 34 existing Windows temporary-directory cleanup errors in `tests/test_file_manager.py`.

Related to #16
