### PR TITLE
test: add unit tests for easy_web module (closes #15)

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock, patch
+import pytest
+import requests
+
+from py_simple_package.src.py_simple.easy_web import get_page_content, is_page_up
+
+
+class TestEasyWeb:
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_page_content_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.text = "<html><body><h1>Hello World</h1></body></html>"
+        mock_get.return_value = mock_response
+
+        content = get_page_content("https://example.com")
+        assert content is not None
+        assert "Hello World" in content
+        assert "<h1>" in content
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_page_content_not_ok(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.ok = False
+        mock_get.return_value = mock_response
+
+        content = get_page_content("https://example.com/not-found")
+        assert content is None
+        mock_get.assert_called_once_with("https://example.com/not-found", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_page_content_exception(self, mock_get):
+        mock_get.side_effect = requests.RequestException("Network Error")
+
+        content = get_page_content("https://invalid-url.com")
+        assert content is None
+        mock_get.assert_called_once_with("https://invalid-url.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_is_page_up_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = is_page_up("https://example.com")
+        assert result is True
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_is_page_up_http_error(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.HTTPError("404 Not Found")
+        mock_get.return_value = mock_response
+
+        result = is_page_up("https://example.com/404")
+        assert result is False
+        mock_get.assert_called_once_with("https://example.com/404", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_is_page_up_connection_error(self, mock_get):
+        mock_get.side_effect = requests.ConnectionError("Connection Failed")
+
+        result = is_page_up("https://offline-site.com")
+        assert result is False
+        mock_get.assert_called_once_with("https://offline-site.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_is_page_up_non_200_status(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = is_page_up("https://example.com/created")
+        assert result is False
+        mock_get.assert_called_once_with("https://example.com/created", timeout=10)


### PR DESCRIPTION
### Summary
This PR implements comprehensive unit tests for the  module as requested in #15.

### Changes Made
- Added  covering all functions in  using ============================= test session starts ==============================
platform linux -- Python 3.14.4, pytest-9.0.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /mnt/data/py_simple
configfile: pyproject.toml
testpaths: tests
plugins: asyncio-1.4.0, typeguard-4.4.4
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 215 items

tests/test_converter.py::test_seconds_to_hh_mm_ss[0-0:00:00] PASSED      [  0%]
tests/test_converter.py::test_seconds_to_hh_mm_ss[90-0:01:30] PASSED     [  0%]
tests/test_converter.py::test_seconds_to_hh_mm_ss[3661-1:01:01] PASSED   [  1%]
tests/test_converter.py::test_seconds_to_hh_mm_ss[-1--1 day, 23:59:59] PASSED [  1%]
tests/test_converter.py::test_hh_mm_ss_to_seconds[0-0-0-0] PASSED        [  2%]
tests/test_converter.py::test_hh_mm_ss_to_seconds[1-1-1-3661] PASSED     [  2%]
tests/test_converter.py::test_hh_mm_ss_to_seconds[0-90-0-5400] PASSED    [  3%]
tests/test_converter.py::test_hh_mm_ss_to_seconds[-1-30-0--1800] PASSED  [  3%]
tests/test_converter.py::test_hh_mm_ss_to_seconds_uses_zero_defaults PASSED [  4%]
tests/test_converter.py::test_distance_weight_and_area_conversions[km_to_mile-100-62.14] PASSED [  4%]
tests/test_converter.py::test_distance_weight_and_area_conversions[km_to_mile-0-0.0] PASSED [  5%]
tests/test_converter.py::test_distance_weight_and_area_conversions[miles_to_km-100-160.93] PASSED [  5%]
tests/test_converter.py::test_distance_weight_and_area_conversions[miles_to_km-0-0.0] PASSED [  6%]
tests/test_converter.py::test_distance_weight_and_area_conversions[kg_to_lb-50-110.23] PASSED [  6%]
tests/test_converter.py::test_distance_weight_and_area_conversions[kg_to_lb-0-0.0] PASSED [  6%]
tests/test_converter.py::test_distance_weight_and_area_conversions[lb_to_kg-110.23-50.0] PASSED [  7%]
tests/test_converter.py::test_distance_weight_and_area_conversions[lb_to_kg-0-0.0] PASSED [  7%]
tests/test_converter.py::test_distance_weight_and_area_conversions[meters_to_feet-100-328.08] PASSED [  8%]
tests/test_converter.py::test_distance_weight_and_area_conversions[meters_to_feet-0-0.0] PASSED [  8%]
tests/test_converter.py::test_distance_weight_and_area_conversions[feet_to_meters-328.08-100.0] PASSED [  9%]
tests/test_converter.py::test_distance_weight_and_area_conversions[feet_to_meters-0-0.0] PASSED [  9%]
tests/test_converter.py::test_distance_weight_and_area_conversions[cm_to_inches-100-39.37] PASSED [ 10%]
tests/test_converter.py::test_distance_weight_and_area_conversions[cm_to_inches-0-0.0] PASSED [ 10%]
tests/test_converter.py::test_distance_weight_and_area_conversions[inches_to_cm-39.37-100.0] PASSED [ 11%]
tests/test_converter.py::test_distance_weight_and_area_conversions[inches_to_cm-0-0.0] PASSED [ 11%]
tests/test_converter.py::test_distance_weight_and_area_conversions[sq_meters_to_sq_feet-10-107.64] PASSED [ 12%]
tests/test_converter.py::test_distance_weight_and_area_conversions[sq_meters_to_sq_feet-0-0.0] PASSED [ 12%]
tests/test_converter.py::test_distance_weight_and_area_conversions[sq_feet_to_sq_meters-107.64-10.0] PASSED [ 13%]
tests/test_converter.py::test_distance_weight_and_area_conversions[sq_feet_to_sq_meters-0-0.0] PASSED [ 13%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[km_to_mile--10--6.21] PASSED [ 13%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[miles_to_km--10--16.09] PASSED [ 14%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[kg_to_lb--5--11.02] PASSED [ 14%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[lb_to_kg--5--2.27] PASSED [ 15%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[meters_to_feet--2--6.56] PASSED [ 15%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[feet_to_meters--2--0.61] PASSED [ 16%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[cm_to_inches--2.54--1.0] PASSED [ 16%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[inches_to_cm--1--2.54] PASSED [ 17%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[sq_meters_to_sq_feet--1--10.76] PASSED [ 17%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[sq_feet_to_sq_meters--1--0.09] PASSED [ 18%]
tests/test_converter.py::test_fluid_oz_to_ml_supported_standards[us-29.6] PASSED [ 18%]
tests/test_converter.py::test_fluid_oz_to_ml_supported_standards[uk-28.4] PASSED [ 19%]
tests/test_converter.py::test_fluid_oz_to_ml_defaults_to_us_standard PASSED [ 19%]
tests/test_converter.py::test_ml_to_fluid_oz_supported_standards[us-3.4] PASSED [ 20%]
tests/test_converter.py::test_ml_to_fluid_oz_supported_standards[uk-3.5] PASSED [ 20%]
tests/test_converter.py::test_ml_to_fluid_oz_defaults_to_us_standard PASSED [ 20%]
tests/test_converter.py::test_fluid_converters_return_none_for_unknown_standard[] PASSED [ 21%]
tests/test_converter.py::test_fluid_converters_return_none_for_unknown_standard[US] PASSED [ 21%]
tests/test_converter.py::test_fluid_converters_return_none_for_unknown_standard[imperial] PASSED [ 22%]
tests/test_converter.py::test_fluid_converters_return_none_for_unknown_standard[None] PASSED [ 22%]
tests/test_converter.py::test_celsius_to_fahrenheit[-40--40.0] PASSED    [ 23%]
tests/test_converter.py::test_celsius_to_fahrenheit[0-32.0] PASSED       [ 23%]
tests/test_converter.py::test_celsius_to_fahrenheit[37-98.6] PASSED      [ 24%]
tests/test_converter.py::test_celsius_to_fahrenheit[100-212.0] PASSED    [ 24%]
tests/test_converter.py::test_fahrenheit_to_celsius[-40--40.0] PASSED    [ 25%]
tests/test_converter.py::test_fahrenheit_to_celsius[32-0.0] PASSED       [ 25%]
tests/test_converter.py::test_fahrenheit_to_celsius[98.6-37.0] PASSED    [ 26%]
tests/test_converter.py::test_fahrenheit_to_celsius[212-100.0] PASSED    [ 26%]
tests/test_date_formatter.py::TestPrettyDates::test_get_pretty_date_format PASSED [ 26%]
tests/test_date_formatter.py::TestPrettyDates::test_get_past_pretty_date_returns_string PASSED [ 27%]
tests/test_date_formatter.py::TestPrettyDates::test_get_past_pretty_date_zero_days PASSED [ 27%]
tests/test_date_formatter.py::TestPrettyDates::test_get_past_pretty_date_one_day PASSED [ 28%]
tests/test_date_formatter.py::TestPrettyDates::test_get_future_pretty_date PASSED [ 28%]
tests/test_date_formatter.py::TestPrettyDates::test_get_future_pretty_date_zero_days PASSED [ 29%]
tests/test_date_formatter.py::TestPrettyDates::test_get_future_pretty_date_one_day PASSED [ 29%]
tests/test_date_formatter.py::TestHyphenatedDates::test_dd_mm_yyyy_format PASSED [ 30%]
tests/test_date_formatter.py::TestHyphenatedDates::test_mm_dd_yyyy_format PASSED [ 30%]
tests/test_date_formatter.py::TestHyphenatedDates::test_dd_mm_yyyy_vs_mm_dd_yyyy_are_different PASSED [ 31%]
tests/test_date_formatter.py::TestHyphenatedDates::test_past_dd_mm_yyyy PASSED [ 31%]
tests/test_date_formatter.py::TestHyphenatedDates::test_future_dd_mm_yyyy PASSED [ 32%]
tests/test_date_formatter.py::TestHyphenatedDates::test_past_vs_future_symmetry PASSED [ 32%]
tests/test_date_formatter.py::TestSlashDates::test_slash_dd_mm_yyyy_format PASSED [ 33%]
tests/test_date_formatter.py::TestSlashDates::test_slash_mm_dd_yyyy_format PASSED [ 33%]
tests/test_date_formatter.py::TestSlashDates::test_past_slash_vs_current PASSED [ 33%]
tests/test_date_formatter.py::TestSlashDates::test_future_slash_vs_current PASSED [ 34%]
tests/test_date_formatter.py::TestUtilityFunctions::test_list_available_formats PASSED [ 34%]
tests/test_date_formatter.py::TestUtilityFunctions::test_negative_days_ago PASSED [ 35%]
tests/test_date_formatter.py::TestUtilityFunctions::test_negative_days_future PASSED [ 35%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_past_periods[1] PASSED [ 36%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_past_periods[3] PASSED [ 36%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_past_periods[7] PASSED [ 37%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_past_periods[30] PASSED [ 37%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_past_periods[365] PASSED [ 38%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_future_periods[1] PASSED [ 38%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_future_periods[3] PASSED [ 39%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_future_periods[7] PASSED [ 39%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_future_periods[30] PASSED [ 40%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_future_periods[365] PASSED [ 40%]
tests/test_file_manager.py::TestMakeBlankFile::test_creates_file PASSED  [ 40%]
tests/test_file_manager.py::TestMakeBlankFile::test_does_not_overwrite PASSED [ 41%]
tests/test_file_manager.py::TestMakeBlankFile::test_invalid_extension_raises PASSED [ 41%]
tests/test_file_manager.py::TestMakeBlankFile::test_all_valid_extensions[txt] PASSED [ 42%]
tests/test_file_manager.py::TestMakeBlankFile::test_all_valid_extensions[md] PASSED [ 42%]
tests/test_file_manager.py::TestMakeBlankFile::test_all_valid_extensions[log] PASSED [ 43%]
tests/test_file_manager.py::TestMakeBlankFile::test_all_valid_extensions[csv] PASSED [ 43%]
tests/test_file_manager.py::TestAddALine::test_append_to_existing_file PASSED [ 44%]
tests/test_file_manager.py::TestAddALine::test_creates_file_if_not_exists PASSED [ 44%]
tests/test_file_manager.py::TestAddALine::test_multiple_lines PASSED     [ 45%]
tests/test_file_manager.py::TestAddALine::test_invalid_extension_raises PASSED [ 45%]
tests/test_file_manager.py::TestReadFileToList::test_read_empty_file PASSED [ 46%]
tests/test_file_manager.py::TestReadFileToList::test_read_non_existent_file PASSED [ 46%]
tests/test_file_manager.py::TestReadFileToList::test_strips_whitespace PASSED [ 46%]
tests/test_file_manager.py::TestReadFileToList::test_invalid_extension_raises PASSED [ 47%]
tests/test_file_manager.py::TestRemoveFile::test_removes_existing_file PASSED [ 47%]
tests/test_file_manager.py::TestRemoveFile::test_remove_nonexistent PASSED [ 48%]
tests/test_file_manager.py::TestRemoveFile::test_invalid_extension_raises PASSED [ 48%]
tests/test_file_manager.py::TestRenameFile::test_rename_existing_file PASSED [ 49%]
tests/test_file_manager.py::TestRenameFile::test_rename_to_existing_name PASSED [ 49%]
tests/test_file_manager.py::TestRenameFile::test_rename_nonexistent PASSED [ 50%]
tests/test_file_manager.py::TestRenameFile::test_invalid_extension_raises PASSED [ 50%]
tests/test_file_manager.py::TestListFiles::test_lists_valid_files PASSED [ 51%]
tests/test_file_manager.py::TestListFiles::test_filter_by_extension PASSED [ 51%]
tests/test_file_manager.py::TestListFiles::test_skip_hidden_and_invalid PASSED [ 52%]
tests/test_file_manager.py::TestListFiles::test_invalid_extension_filter_raises PASSED [ 52%]
tests/test_file_manager.py::TestCopyFile::test_copy_file PASSED          [ 53%]
tests/test_file_manager.py::TestCopyFile::test_copy_nonexistent_source PASSED [ 53%]
tests/test_file_manager.py::TestCopyFile::test_copy_to_existing_destination PASSED [ 53%]
tests/test_file_manager.py::TestCopyFile::test_invalid_source_extension_raises PASSED [ 54%]
tests/test_file_manager.py::TestCopyFile::test_invalid_dest_extension_raises PASSED [ 54%]
tests/test_file_manager.py::TestIsFileThere::test_existing_file PASSED   [ 55%]
tests/test_file_manager.py::TestIsFileThere::test_missing_file PASSED    [ 55%]
tests/test_file_manager.py::TestIsFileThere::test_directory_not_file PASSED [ 56%]
tests/test_numbers.py::test_is_even_with_even_number PASSED              [ 56%]
tests/test_numbers.py::test_is_even_with_odd_number PASSED               [ 57%]
tests/test_numbers.py::test_is_even_with_zero PASSED                     [ 57%]
tests/test_numbers.py::test_is_even_with_negative_even PASSED            [ 58%]
tests/test_numbers.py::test_is_even_with_negative_odd PASSED             [ 58%]
tests/test_numbers.py::test_is_odd_with_odd_number PASSED                [ 59%]
tests/test_numbers.py::test_is_odd_with_even_number PASSED               [ 59%]
tests/test_numbers.py::test_is_odd_with_zero PASSED                      [ 60%]
tests/test_numbers.py::test_is_odd_with_negative_odd PASSED              [ 60%]
tests/test_numbers.py::test_is_odd_with_negative_even PASSED             [ 60%]
tests/test_numbers.py::test_is_evenly_divisible_true PASSED              [ 61%]
tests/test_numbers.py::test_is_evenly_divisible_false PASSED             [ 61%]
tests/test_numbers.py::test_is_evenly_divisible_by_one PASSED            [ 62%]
tests/test_numbers.py::test_is_evenly_divisible_equal_numbers PASSED     [ 62%]
tests/test_numbers.py::test_is_evenly_divisible_negative_number PASSED   [ 63%]
tests/test_numbers.py::test_is_evenly_divisible_negative_divisor PASSED  [ 63%]
tests/test_numbers.py::test_is_evenly_divisible_both_negative PASSED     [ 64%]
tests/test_numbers.py::test_is_positive_positive PASSED                  [ 64%]
tests/test_numbers.py::test_is_positive_negative PASSED                  [ 65%]
tests/test_numbers.py::test_is_positive_zero PASSED                      [ 65%]
tests/test_numbers.py::test_is_negative_negative PASSED                  [ 66%]
tests/test_numbers.py::test_is_negative_positive PASSED                  [ 66%]
tests/test_numbers.py::test_is_negative_zero PASSED                      [ 66%]
tests/test_numbers.py::test_average_integers PASSED                      [ 67%]
tests/test_numbers.py::test_average_floats PASSED                        [ 67%]
tests/test_numbers.py::test_average_single_number PASSED                 [ 68%]
tests/test_numbers.py::test_average_negative_numbers PASSED              [ 68%]
tests/test_numbers.py::test_average_rounding PASSED                      [ 69%]
tests/test_numbers.py::test_is_prime_two PASSED                          [ 69%]
tests/test_numbers.py::test_is_prime_three PASSED                        [ 70%]
tests/test_numbers.py::test_is_prime_composite PASSED                    [ 70%]
tests/test_numbers.py::test_is_prime_large_prime PASSED                  [ 71%]
tests/test_numbers.py::test_is_prime_one PASSED                          [ 71%]
tests/test_numbers.py::test_is_prime_zero PASSED                         [ 72%]
tests/test_numbers.py::test_percentage_half PASSED                       [ 72%]
tests/test_numbers.py::test_percentage_quarter PASSED                    [ 73%]
tests/test_numbers.py::test_percentage_zero PASSED                       [ 73%]
tests/test_numbers.py::test_percentage_decimal PASSED                    [ 73%]
tests/test_strings.py::test_remove_extra_spaces[  hello   world  -hello world] PASSED [ 74%]
tests/test_strings.py::test_remove_extra_spaces[hello world-hello world] PASSED [ 74%]
tests/test_strings.py::test_remove_extra_spaces[-] PASSED                [ 75%]
tests/test_strings.py::test_remove_extra_spaces[   -] PASSED             [ 75%]
tests/test_strings.py::test_remove_extra_spaces[hello	world
again-hello world again] PASSED [ 76%]
tests/test_strings.py::test_to_snake_case[Hello World-hello_world] PASSED [ 76%]
tests/test_strings.py::test_to_snake_case[hello-world-hello_world] PASSED [ 77%]
tests/test_strings.py::test_to_snake_case[hello_world-hello_world] PASSED [ 77%]
tests/test_strings.py::test_to_snake_case[helloWorld-hello_world] PASSED [ 78%]
tests/test_strings.py::test_to_snake_case[  Multiple   Spaces  -multiple_spaces] PASSED [ 78%]
tests/test_strings.py::test_to_snake_case[Python 3 Basics-python_3_basics] PASSED [ 79%]
tests/test_strings.py::test_to_kebab_case[Hello World-hello-world] PASSED [ 79%]
tests/test_strings.py::test_to_kebab_case[hello_world-hello-world] PASSED [ 80%]
tests/test_strings.py::test_to_kebab_case[hello-world-hello-world] PASSED [ 80%]
tests/test_strings.py::test_to_kebab_case[helloWorld-hello-world] PASSED [ 80%]
tests/test_strings.py::test_to_kebab_case[  Multiple   Spaces  -multiple-spaces] PASSED [ 81%]
tests/test_strings.py::test_to_kebab_case[Python 3 Basics-python-3-basics] PASSED [ 81%]
tests/test_strings.py::test_is_palindrome[racecar-True] PASSED           [ 82%]
tests/test_strings.py::test_is_palindrome[RaceCar-True] PASSED           [ 82%]
tests/test_strings.py::test_is_palindrome[Never odd or even-True] PASSED [ 83%]
tests/test_strings.py::test_is_palindrome[A man, a plan, a canal: Panama!-True] PASSED [ 83%]
tests/test_strings.py::test_is_palindrome[hello-False] PASSED            [ 84%]
tests/test_strings.py::test_is_palindrome[-True] PASSED                  [ 84%]
tests/test_validator.py::TestEasyValidator::test_email_validation[mymail@gmail.com-True] PASSED [ 85%]
tests/test_validator.py::TestEasyValidator::test_email_validation[email.com-False] PASSED [ 85%]
tests/test_validator.py::TestEasyValidator::test_email_validation[-False] PASSED [ 86%]
tests/test_validator.py::TestEasyValidator::test_email_validation[user@test.co-True] PASSED [ 86%]
tests/test_validator.py::TestEasyValidator::test_email_validation[@gmail.com-False] PASSED [ 86%]
tests/test_validator.py::TestEasyValidator::test_username_validation[user_name-True] PASSED [ 87%]
tests/test_validator.py::TestEasyValidator::test_username_validation[user.name-False] PASSED [ 87%]
tests/test_validator.py::TestEasyValidator::test_username_validation[user123-True] PASSED [ 88%]
tests/test_validator.py::TestEasyValidator::test_username_validation[-False] PASSED [ 88%]
tests/test_validator.py::TestEasyValidator::test_username_validation[user-name-False] PASSED [ 89%]
tests/test_validator.py::TestEasyValidator::test_zipcode_validation[12345-True] PASSED [ 89%]
tests/test_validator.py::TestEasyValidator::test_zipcode_validation[1248721-False] PASSED [ 90%]
tests/test_validator.py::TestEasyValidator::test_zipcode_validation[1234-False] PASSED [ 90%]
tests/test_validator.py::TestEasyValidator::test_zipcode_validation[99999-True] PASSED [ 91%]
tests/test_validator.py::TestEasyValidator::test_zipcode_validation[01234-True] PASSED [ 91%]
tests/test_validator.py::TestEasyValidator::test_url_validation[www.google.com-True] PASSED [ 92%]
tests/test_validator.py::TestEasyValidator::test_url_validation[something.com-False] PASSED [ 92%]
tests/test_validator.py::TestEasyValidator::test_url_validation[http://google.com-True] PASSED [ 93%]
tests/test_validator.py::TestEasyValidator::test_url_validation[https://google.com-True] PASSED [ 93%]
tests/test_validator.py::TestEasyValidator::test_url_validation[-False] PASSED [ 93%]
tests/test_validator.py::TestEasyValidator::test_password_validation[1andkrf!AG5-True] PASSED [ 94%]
tests/test_validator.py::TestEasyValidator::test_password_validation[111mskagowd-False] PASSED [ 94%]
tests/test_validator.py::TestEasyValidator::test_password_validation[Ab1!cd-False] PASSED [ 95%]
tests/test_validator.py::TestEasyValidator::test_password_validation[abcd12!ef-False] PASSED [ 95%]
tests/test_validator.py::TestEasyValidator::test_password_validation[Abcdef!g1-False] PASSED [ 96%]
tests/test_validator.py::TestEasyValidator::test_password_validation[Abcd12!!Ef-False] PASSED [ 96%]
tests/test_web.py::TestEasyWeb::test_get_page_content_success PASSED     [ 97%]
tests/test_web.py::TestEasyWeb::test_get_page_content_not_ok PASSED      [ 97%]
tests/test_web.py::TestEasyWeb::test_get_page_content_exception PASSED   [ 98%]
tests/test_web.py::TestEasyWeb::test_is_page_up_success PASSED           [ 98%]
tests/test_web.py::TestEasyWeb::test_is_page_up_http_error PASSED        [ 99%]
tests/test_web.py::TestEasyWeb::test_is_page_up_connection_error PASSED  [ 99%]
tests/test_web.py::TestEasyWeb::test_is_page_up_non_200_status PASSED    [100%]

============================= 215 passed in 0.32s ============================== and .
- Added tests for :
  - Successful page content fetching & HTML parsing with BeautifulSoup prettify.
  - Returns  when response is not OK (e.g., 404, 500).
  - Returns  when network exceptions occur ().
- Added tests for :
  - Returns  when page returns HTTP status 200.
  - Returns  on HTTP errors ().
  - Returns  on connection failures.
  - Returns  on non-200 successful statuses (e.g., 201).

### Verification
All 215 unit tests pass (============================= test session starts ==============================
platform linux -- Python 3.14.4, pytest-9.0.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /mnt/data/py_simple
configfile: pyproject.toml
testpaths: tests
plugins: asyncio-1.4.0, typeguard-4.4.4
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 215 items

tests/test_converter.py::test_seconds_to_hh_mm_ss[0-0:00:00] PASSED      [  0%]
tests/test_converter.py::test_seconds_to_hh_mm_ss[90-0:01:30] PASSED     [  0%]
tests/test_converter.py::test_seconds_to_hh_mm_ss[3661-1:01:01] PASSED   [  1%]
tests/test_converter.py::test_seconds_to_hh_mm_ss[-1--1 day, 23:59:59] PASSED [  1%]
tests/test_converter.py::test_hh_mm_ss_to_seconds[0-0-0-0] PASSED        [  2%]
tests/test_converter.py::test_hh_mm_ss_to_seconds[1-1-1-3661] PASSED     [  2%]
tests/test_converter.py::test_hh_mm_ss_to_seconds[0-90-0-5400] PASSED    [  3%]
tests/test_converter.py::test_hh_mm_ss_to_seconds[-1-30-0--1800] PASSED  [  3%]
tests/test_converter.py::test_hh_mm_ss_to_seconds_uses_zero_defaults PASSED [  4%]
tests/test_converter.py::test_distance_weight_and_area_conversions[km_to_mile-100-62.14] PASSED [  4%]
tests/test_converter.py::test_distance_weight_and_area_conversions[km_to_mile-0-0.0] PASSED [  5%]
tests/test_converter.py::test_distance_weight_and_area_conversions[miles_to_km-100-160.93] PASSED [  5%]
tests/test_converter.py::test_distance_weight_and_area_conversions[miles_to_km-0-0.0] PASSED [  6%]
tests/test_converter.py::test_distance_weight_and_area_conversions[kg_to_lb-50-110.23] PASSED [  6%]
tests/test_converter.py::test_distance_weight_and_area_conversions[kg_to_lb-0-0.0] PASSED [  6%]
tests/test_converter.py::test_distance_weight_and_area_conversions[lb_to_kg-110.23-50.0] PASSED [  7%]
tests/test_converter.py::test_distance_weight_and_area_conversions[lb_to_kg-0-0.0] PASSED [  7%]
tests/test_converter.py::test_distance_weight_and_area_conversions[meters_to_feet-100-328.08] PASSED [  8%]
tests/test_converter.py::test_distance_weight_and_area_conversions[meters_to_feet-0-0.0] PASSED [  8%]
tests/test_converter.py::test_distance_weight_and_area_conversions[feet_to_meters-328.08-100.0] PASSED [  9%]
tests/test_converter.py::test_distance_weight_and_area_conversions[feet_to_meters-0-0.0] PASSED [  9%]
tests/test_converter.py::test_distance_weight_and_area_conversions[cm_to_inches-100-39.37] PASSED [ 10%]
tests/test_converter.py::test_distance_weight_and_area_conversions[cm_to_inches-0-0.0] PASSED [ 10%]
tests/test_converter.py::test_distance_weight_and_area_conversions[inches_to_cm-39.37-100.0] PASSED [ 11%]
tests/test_converter.py::test_distance_weight_and_area_conversions[inches_to_cm-0-0.0] PASSED [ 11%]
tests/test_converter.py::test_distance_weight_and_area_conversions[sq_meters_to_sq_feet-10-107.64] PASSED [ 12%]
tests/test_converter.py::test_distance_weight_and_area_conversions[sq_meters_to_sq_feet-0-0.0] PASSED [ 12%]
tests/test_converter.py::test_distance_weight_and_area_conversions[sq_feet_to_sq_meters-107.64-10.0] PASSED [ 13%]
tests/test_converter.py::test_distance_weight_and_area_conversions[sq_feet_to_sq_meters-0-0.0] PASSED [ 13%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[km_to_mile--10--6.21] PASSED [ 13%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[miles_to_km--10--16.09] PASSED [ 14%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[kg_to_lb--5--11.02] PASSED [ 14%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[lb_to_kg--5--2.27] PASSED [ 15%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[meters_to_feet--2--6.56] PASSED [ 15%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[feet_to_meters--2--0.61] PASSED [ 16%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[cm_to_inches--2.54--1.0] PASSED [ 16%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[inches_to_cm--1--2.54] PASSED [ 17%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[sq_meters_to_sq_feet--1--10.76] PASSED [ 17%]
tests/test_converter.py::test_scalar_conversions_preserve_negative_sign[sq_feet_to_sq_meters--1--0.09] PASSED [ 18%]
tests/test_converter.py::test_fluid_oz_to_ml_supported_standards[us-29.6] PASSED [ 18%]
tests/test_converter.py::test_fluid_oz_to_ml_supported_standards[uk-28.4] PASSED [ 19%]
tests/test_converter.py::test_fluid_oz_to_ml_defaults_to_us_standard PASSED [ 19%]
tests/test_converter.py::test_ml_to_fluid_oz_supported_standards[us-3.4] PASSED [ 20%]
tests/test_converter.py::test_ml_to_fluid_oz_supported_standards[uk-3.5] PASSED [ 20%]
tests/test_converter.py::test_ml_to_fluid_oz_defaults_to_us_standard PASSED [ 20%]
tests/test_converter.py::test_fluid_converters_return_none_for_unknown_standard[] PASSED [ 21%]
tests/test_converter.py::test_fluid_converters_return_none_for_unknown_standard[US] PASSED [ 21%]
tests/test_converter.py::test_fluid_converters_return_none_for_unknown_standard[imperial] PASSED [ 22%]
tests/test_converter.py::test_fluid_converters_return_none_for_unknown_standard[None] PASSED [ 22%]
tests/test_converter.py::test_celsius_to_fahrenheit[-40--40.0] PASSED    [ 23%]
tests/test_converter.py::test_celsius_to_fahrenheit[0-32.0] PASSED       [ 23%]
tests/test_converter.py::test_celsius_to_fahrenheit[37-98.6] PASSED      [ 24%]
tests/test_converter.py::test_celsius_to_fahrenheit[100-212.0] PASSED    [ 24%]
tests/test_converter.py::test_fahrenheit_to_celsius[-40--40.0] PASSED    [ 25%]
tests/test_converter.py::test_fahrenheit_to_celsius[32-0.0] PASSED       [ 25%]
tests/test_converter.py::test_fahrenheit_to_celsius[98.6-37.0] PASSED    [ 26%]
tests/test_converter.py::test_fahrenheit_to_celsius[212-100.0] PASSED    [ 26%]
tests/test_date_formatter.py::TestPrettyDates::test_get_pretty_date_format PASSED [ 26%]
tests/test_date_formatter.py::TestPrettyDates::test_get_past_pretty_date_returns_string PASSED [ 27%]
tests/test_date_formatter.py::TestPrettyDates::test_get_past_pretty_date_zero_days PASSED [ 27%]
tests/test_date_formatter.py::TestPrettyDates::test_get_past_pretty_date_one_day PASSED [ 28%]
tests/test_date_formatter.py::TestPrettyDates::test_get_future_pretty_date PASSED [ 28%]
tests/test_date_formatter.py::TestPrettyDates::test_get_future_pretty_date_zero_days PASSED [ 29%]
tests/test_date_formatter.py::TestPrettyDates::test_get_future_pretty_date_one_day PASSED [ 29%]
tests/test_date_formatter.py::TestHyphenatedDates::test_dd_mm_yyyy_format PASSED [ 30%]
tests/test_date_formatter.py::TestHyphenatedDates::test_mm_dd_yyyy_format PASSED [ 30%]
tests/test_date_formatter.py::TestHyphenatedDates::test_dd_mm_yyyy_vs_mm_dd_yyyy_are_different PASSED [ 31%]
tests/test_date_formatter.py::TestHyphenatedDates::test_past_dd_mm_yyyy PASSED [ 31%]
tests/test_date_formatter.py::TestHyphenatedDates::test_future_dd_mm_yyyy PASSED [ 32%]
tests/test_date_formatter.py::TestHyphenatedDates::test_past_vs_future_symmetry PASSED [ 32%]
tests/test_date_formatter.py::TestSlashDates::test_slash_dd_mm_yyyy_format PASSED [ 33%]
tests/test_date_formatter.py::TestSlashDates::test_slash_mm_dd_yyyy_format PASSED [ 33%]
tests/test_date_formatter.py::TestSlashDates::test_past_slash_vs_current PASSED [ 33%]
tests/test_date_formatter.py::TestSlashDates::test_future_slash_vs_current PASSED [ 34%]
tests/test_date_formatter.py::TestUtilityFunctions::test_list_available_formats PASSED [ 34%]
tests/test_date_formatter.py::TestUtilityFunctions::test_negative_days_ago PASSED [ 35%]
tests/test_date_formatter.py::TestUtilityFunctions::test_negative_days_future PASSED [ 35%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_past_periods[1] PASSED [ 36%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_past_periods[3] PASSED [ 36%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_past_periods[7] PASSED [ 37%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_past_periods[30] PASSED [ 37%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_past_periods[365] PASSED [ 38%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_future_periods[1] PASSED [ 38%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_future_periods[3] PASSED [ 39%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_future_periods[7] PASSED [ 39%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_future_periods[30] PASSED [ 40%]
tests/test_date_formatter.py::TestUtilityFunctions::test_various_future_periods[365] PASSED [ 40%]
tests/test_file_manager.py::TestMakeBlankFile::test_creates_file PASSED  [ 40%]
tests/test_file_manager.py::TestMakeBlankFile::test_does_not_overwrite PASSED [ 41%]
tests/test_file_manager.py::TestMakeBlankFile::test_invalid_extension_raises PASSED [ 41%]
tests/test_file_manager.py::TestMakeBlankFile::test_all_valid_extensions[txt] PASSED [ 42%]
tests/test_file_manager.py::TestMakeBlankFile::test_all_valid_extensions[md] PASSED [ 42%]
tests/test_file_manager.py::TestMakeBlankFile::test_all_valid_extensions[log] PASSED [ 43%]
tests/test_file_manager.py::TestMakeBlankFile::test_all_valid_extensions[csv] PASSED [ 43%]
tests/test_file_manager.py::TestAddALine::test_append_to_existing_file PASSED [ 44%]
tests/test_file_manager.py::TestAddALine::test_creates_file_if_not_exists PASSED [ 44%]
tests/test_file_manager.py::TestAddALine::test_multiple_lines PASSED     [ 45%]
tests/test_file_manager.py::TestAddALine::test_invalid_extension_raises PASSED [ 45%]
tests/test_file_manager.py::TestReadFileToList::test_read_empty_file PASSED [ 46%]
tests/test_file_manager.py::TestReadFileToList::test_read_non_existent_file PASSED [ 46%]
tests/test_file_manager.py::TestReadFileToList::test_strips_whitespace PASSED [ 46%]
tests/test_file_manager.py::TestReadFileToList::test_invalid_extension_raises PASSED [ 47%]
tests/test_file_manager.py::TestRemoveFile::test_removes_existing_file PASSED [ 47%]
tests/test_file_manager.py::TestRemoveFile::test_remove_nonexistent PASSED [ 48%]
tests/test_file_manager.py::TestRemoveFile::test_invalid_extension_raises PASSED [ 48%]
tests/test_file_manager.py::TestRenameFile::test_rename_existing_file PASSED [ 49%]
tests/test_file_manager.py::TestRenameFile::test_rename_to_existing_name PASSED [ 49%]
tests/test_file_manager.py::TestRenameFile::test_rename_nonexistent PASSED [ 50%]
tests/test_file_manager.py::TestRenameFile::test_invalid_extension_raises PASSED [ 50%]
tests/test_file_manager.py::TestListFiles::test_lists_valid_files PASSED [ 51%]
tests/test_file_manager.py::TestListFiles::test_filter_by_extension PASSED [ 51%]
tests/test_file_manager.py::TestListFiles::test_skip_hidden_and_invalid PASSED [ 52%]
tests/test_file_manager.py::TestListFiles::test_invalid_extension_filter_raises PASSED [ 52%]
tests/test_file_manager.py::TestCopyFile::test_copy_file PASSED          [ 53%]
tests/test_file_manager.py::TestCopyFile::test_copy_nonexistent_source PASSED [ 53%]
tests/test_file_manager.py::TestCopyFile::test_copy_to_existing_destination PASSED [ 53%]
tests/test_file_manager.py::TestCopyFile::test_invalid_source_extension_raises PASSED [ 54%]
tests/test_file_manager.py::TestCopyFile::test_invalid_dest_extension_raises PASSED [ 54%]
tests/test_file_manager.py::TestIsFileThere::test_existing_file PASSED   [ 55%]
tests/test_file_manager.py::TestIsFileThere::test_missing_file PASSED    [ 55%]
tests/test_file_manager.py::TestIsFileThere::test_directory_not_file PASSED [ 56%]
tests/test_numbers.py::test_is_even_with_even_number PASSED              [ 56%]
tests/test_numbers.py::test_is_even_with_odd_number PASSED               [ 57%]
tests/test_numbers.py::test_is_even_with_zero PASSED                     [ 57%]
tests/test_numbers.py::test_is_even_with_negative_even PASSED            [ 58%]
tests/test_numbers.py::test_is_even_with_negative_odd PASSED             [ 58%]
tests/test_numbers.py::test_is_odd_with_odd_number PASSED                [ 59%]
tests/test_numbers.py::test_is_odd_with_even_number PASSED               [ 59%]
tests/test_numbers.py::test_is_odd_with_zero PASSED                      [ 60%]
tests/test_numbers.py::test_is_odd_with_negative_odd PASSED              [ 60%]
tests/test_numbers.py::test_is_odd_with_negative_even PASSED             [ 60%]
tests/test_numbers.py::test_is_evenly_divisible_true PASSED              [ 61%]
tests/test_numbers.py::test_is_evenly_divisible_false PASSED             [ 61%]
tests/test_numbers.py::test_is_evenly_divisible_by_one PASSED            [ 62%]
tests/test_numbers.py::test_is_evenly_divisible_equal_numbers PASSED     [ 62%]
tests/test_numbers.py::test_is_evenly_divisible_negative_number PASSED   [ 63%]
tests/test_numbers.py::test_is_evenly_divisible_negative_divisor PASSED  [ 63%]
tests/test_numbers.py::test_is_evenly_divisible_both_negative PASSED     [ 64%]
tests/test_numbers.py::test_is_positive_positive PASSED                  [ 64%]
tests/test_numbers.py::test_is_positive_negative PASSED                  [ 65%]
tests/test_numbers.py::test_is_positive_zero PASSED                      [ 65%]
tests/test_numbers.py::test_is_negative_negative PASSED                  [ 66%]
tests/test_numbers.py::test_is_negative_positive PASSED                  [ 66%]
tests/test_numbers.py::test_is_negative_zero PASSED                      [ 66%]
tests/test_numbers.py::test_average_integers PASSED                      [ 67%]
tests/test_numbers.py::test_average_floats PASSED                        [ 67%]
tests/test_numbers.py::test_average_single_number PASSED                 [ 68%]
tests/test_numbers.py::test_average_negative_numbers PASSED              [ 68%]
tests/test_numbers.py::test_average_rounding PASSED                      [ 69%]
tests/test_numbers.py::test_is_prime_two PASSED                          [ 69%]
tests/test_numbers.py::test_is_prime_three PASSED                        [ 70%]
tests/test_numbers.py::test_is_prime_composite PASSED                    [ 70%]
tests/test_numbers.py::test_is_prime_large_prime PASSED                  [ 71%]
tests/test_numbers.py::test_is_prime_one PASSED                          [ 71%]
tests/test_numbers.py::test_is_prime_zero PASSED                         [ 72%]
tests/test_numbers.py::test_percentage_half PASSED                       [ 72%]
tests/test_numbers.py::test_percentage_quarter PASSED                    [ 73%]
tests/test_numbers.py::test_percentage_zero PASSED                       [ 73%]
tests/test_numbers.py::test_percentage_decimal PASSED                    [ 73%]
tests/test_strings.py::test_remove_extra_spaces[  hello   world  -hello world] PASSED [ 74%]
tests/test_strings.py::test_remove_extra_spaces[hello world-hello world] PASSED [ 74%]
tests/test_strings.py::test_remove_extra_spaces[-] PASSED                [ 75%]
tests/test_strings.py::test_remove_extra_spaces[   -] PASSED             [ 75%]
tests/test_strings.py::test_remove_extra_spaces[hello	world
again-hello world again] PASSED [ 76%]
tests/test_strings.py::test_to_snake_case[Hello World-hello_world] PASSED [ 76%]
tests/test_strings.py::test_to_snake_case[hello-world-hello_world] PASSED [ 77%]
tests/test_strings.py::test_to_snake_case[hello_world-hello_world] PASSED [ 77%]
tests/test_strings.py::test_to_snake_case[helloWorld-hello_world] PASSED [ 78%]
tests/test_strings.py::test_to_snake_case[  Multiple   Spaces  -multiple_spaces] PASSED [ 78%]
tests/test_strings.py::test_to_snake_case[Python 3 Basics-python_3_basics] PASSED [ 79%]
tests/test_strings.py::test_to_kebab_case[Hello World-hello-world] PASSED [ 79%]
tests/test_strings.py::test_to_kebab_case[hello_world-hello-world] PASSED [ 80%]
tests/test_strings.py::test_to_kebab_case[hello-world-hello-world] PASSED [ 80%]
tests/test_strings.py::test_to_kebab_case[helloWorld-hello-world] PASSED [ 80%]
tests/test_strings.py::test_to_kebab_case[  Multiple   Spaces  -multiple-spaces] PASSED [ 81%]
tests/test_strings.py::test_to_kebab_case[Python 3 Basics-python-3-basics] PASSED [ 81%]
tests/test_strings.py::test_is_palindrome[racecar-True] PASSED           [ 82%]
tests/test_strings.py::test_is_palindrome[RaceCar-True] PASSED           [ 82%]
tests/test_strings.py::test_is_palindrome[Never odd or even-True] PASSED [ 83%]
tests/test_strings.py::test_is_palindrome[A man, a plan, a canal: Panama!-True] PASSED [ 83%]
tests/test_strings.py::test_is_palindrome[hello-False] PASSED            [ 84%]
tests/test_strings.py::test_is_palindrome[-True] PASSED                  [ 84%]
tests/test_validator.py::TestEasyValidator::test_email_validation[mymail@gmail.com-True] PASSED [ 85%]
tests/test_validator.py::TestEasyValidator::test_email_validation[email.com-False] PASSED [ 85%]
tests/test_validator.py::TestEasyValidator::test_email_validation[-False] PASSED [ 86%]
tests/test_validator.py::TestEasyValidator::test_email_validation[user@test.co-True] PASSED [ 86%]
tests/test_validator.py::TestEasyValidator::test_email_validation[@gmail.com-False] PASSED [ 86%]
tests/test_validator.py::TestEasyValidator::test_username_validation[user_name-True] PASSED [ 87%]
tests/test_validator.py::TestEasyValidator::test_username_validation[user.name-False] PASSED [ 87%]
tests/test_validator.py::TestEasyValidator::test_username_validation[user123-True] PASSED [ 88%]
tests/test_validator.py::TestEasyValidator::test_username_validation[-False] PASSED [ 88%]
tests/test_validator.py::TestEasyValidator::test_username_validation[user-name-False] PASSED [ 89%]
tests/test_validator.py::TestEasyValidator::test_zipcode_validation[12345-True] PASSED [ 89%]
tests/test_validator.py::TestEasyValidator::test_zipcode_validation[1248721-False] PASSED [ 90%]
tests/test_validator.py::TestEasyValidator::test_zipcode_validation[1234-False] PASSED [ 90%]
tests/test_validator.py::TestEasyValidator::test_zipcode_validation[99999-True] PASSED [ 91%]
tests/test_validator.py::TestEasyValidator::test_zipcode_validation[01234-True] PASSED [ 91%]
tests/test_validator.py::TestEasyValidator::test_url_validation[www.google.com-True] PASSED [ 92%]
tests/test_validator.py::TestEasyValidator::test_url_validation[something.com-False] PASSED [ 92%]
tests/test_validator.py::TestEasyValidator::test_url_validation[http://google.com-True] PASSED [ 93%]
tests/test_validator.py::TestEasyValidator::test_url_validation[https://google.com-True] PASSED [ 93%]
tests/test_validator.py::TestEasyValidator::test_url_validation[-False] PASSED [ 93%]
tests/test_validator.py::TestEasyValidator::test_password_validation[1andkrf!AG5-True] PASSED [ 94%]
tests/test_validator.py::TestEasyValidator::test_password_validation[111mskagowd-False] PASSED [ 94%]
tests/test_validator.py::TestEasyValidator::test_password_validation[Ab1!cd-False] PASSED [ 95%]
tests/test_validator.py::TestEasyValidator::test_password_validation[abcd12!ef-False] PASSED [ 95%]
tests/test_validator.py::TestEasyValidator::test_password_validation[Abcdef!g1-False] PASSED [ 96%]
tests/test_validator.py::TestEasyValidator::test_password_validation[Abcd12!!Ef-False] PASSED [ 96%]
tests/test_web.py::TestEasyWeb::test_get_page_content_success PASSED     [ 97%]
tests/test_web.py::TestEasyWeb::test_get_page_content_not_ok PASSED      [ 97%]
tests/test_web.py::TestEasyWeb::test_get_page_content_exception PASSED   [ 98%]
tests/test_web.py::TestEasyWeb::test_is_page_up_success PASSED           [ 98%]
tests/test_web.py::TestEasyWeb::test_is_page_up_http_error PASSED        [ 99%]
tests/test_web.py::TestEasyWeb::test_is_page_up_connection_error PASSED  [ 99%]
tests/test_web.py::TestEasyWeb::test_is_page_up_non_200_status PASSED    [100%]

============================= 215 passed in 0.31s ==============================):


Closes #15