### PR TITLE
test(easy_web): add unit tests for get_meta_description and get_all_headers (fixes #44)

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2,7 +2,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from py_simple_package.src.py_simple.easy_web import get_page_content, is_page_up, SomethingWentWrongError
+from py_simple_package.src.py_simple.easy_web import (
+    get_all_headers,
+    get_meta_description,
+    get_page_content,
+    is_page_up,
+    SomethingWentWrongError,
+)
 
 
 class TestEasyWeb:
@@ -77,3 +83,70 @@ class TestEasyWeb:
         result = is_page_up("https://example.com/created")
         assert result is False
         mock_get.assert_called_once_with("https://example.com/created", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_meta_description_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = (
+            b'<html><head>'
+            b'<meta name="description" content="A simple test page">'
+            b'<meta name="keywords" content="python, pytest">'
+            b'<meta name="viewport">'
+            b'</head></html>'
+        )
+        mock_get.return_value = mock_response
+
+        result = get_meta_description("https://example.com")
+        assert result == ["A simple test page", "python, pytest"]
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_meta_description_empty(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = b'<html><head><title>No meta</title></head></html>'
+        mock_get.return_value = mock_response
+
+        result = get_meta_description("https://example.com")
+        assert result == []
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_meta_description_exception(self, mock_get):
+        mock_get.side_effect = requests.RequestException("Request Timed Out")
+
+        with pytest.raises(SomethingWentWrongError):
+            get_meta_description("https://invalid-url.com")
+        mock_get.assert_called_once_with("https://invalid-url.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_all_headers_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = (
+            b'<html><body>'
+            b'<header>\n  Welcome to Py_simple  \n</header>'
+            b'<header>Documentation Header</header>'
+            b'</body></html>'
+        )
+        mock_get.return_value = mock_response
+
+        result = get_all_headers("https://example.com")
+        assert result == ["Welcome to Py_simple", "Documentation Header"]
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_all_headers_empty(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = b'<html><body><div>No header tag</div></body></html>'
+        mock_get.return_value = mock_response
+
+        result = get_all_headers("https://example.com")
+        assert result == []
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_all_headers_exception(self, mock_get):
+        mock_get.side_effect = requests.RequestException("Connection Refused")
+
+        with pytest.raises(SomethingWentWrongError):
+            get_all_headers("https://offline-site.com")
+        mock_get.assert_called_once_with("https://offline-site.com", timeout=10)


### PR DESCRIPTION
…eaders (fixes #44)

Added unit tests in `tests/test_web.py` for the two un-tested functions in `easy_web.py`:

- **`test_get_meta_description`**: Mocked tests covering successful extraction of meta tag content, empty meta tags, and `SomethingWentWrongError` exception handling on network failure.
- **`test_get_all_headers`**: Mocked tests covering successful extraction & whitespace cleaning of `<header>` tags, empty header tags, and `SomethingWentWrongError` exception handling on network failure.

All 13 test cases pass 100% green.

Fixes #44