### PR TITLE
feat: Add easy_colors module for hex and RGB handling (#40)

### DIFF
--- a/docs/reference/easy_colors.md
+++ b/docs/reference/easy_colors.md
@@ -1,0 +1,1 @@
+::: py_simple.easy_colors

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,9 @@ nav:
   - Reference:
       - Easy Numbers: reference/easy_numbers.md
       - Easy Strings: reference/easy_strings.md
+      - Easy Colors: reference/easy_colors.md
       - Easy Web: reference/easy_web.md
+
       - Easy Converter: reference/easy_converter.md
       - Easy Date Formatter: reference/easy_date_formatter.md
       - Easy File Manager: reference/easy_file_manager.md

--- a/py_simple_package/src/py_simple/__init__.py
+++ b/py_simple_package/src/py_simple/__init__.py
@@ -35,3 +35,6 @@ from .easy_strings import (
 from .easy_json import (
     open_json,
 )
+from .easy_colors import (
+    hex_to_rgb, rgb_to_hex, is_valid_hex,
+)

--- a/py_simple_package/src/py_simple/easy_colors.py
+++ b/py_simple_package/src/py_simple/easy_colors.py
@@ -1,0 +1,135 @@
+"""Beginner-friendly helpers for hex and RGB color handling."""
+
+import re
+
+
+def is_valid_hex(hex_code: str) -> bool:
+    """
+    Checks whether a string is a valid hex color code.
+
+    Supports 3-digit and 6-digit hex color formats, with or without
+    a leading '#' prefix.
+
+    Args:
+        hex_code (str): Color string to check.
+
+    Returns:
+        bool: True if hex_code is a valid hex color, False otherwise.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import is_valid_hex
+
+            is_valid_hex("#FFFFFF")  # -> True
+            is_valid_hex("fff")  # -> True
+            is_valid_hex("invalid")  # -> False
+            ```
+
+        === "The Traditional Way"
+            ```python
+            import re
+
+            hex_code = "#FFFFFF"
+            cleaned = hex_code.lstrip("#")
+            is_valid = len(cleaned) in (3, 6) and all(
+                c in "0123456789abcdefABCDEF" for c in cleaned
+            )
+            ```
+    """
+    if not isinstance(hex_code, str):
+        return False
+
+    cleaned = hex_code.lstrip("#")
+    if len(cleaned) not in (3, 6):
+        return False
+
+    return bool(re.fullmatch(r"[0-9a-fA-F]+", cleaned))
+
+
+def hex_to_rgb(hex_code: str) -> tuple[int, int, int]:
+    """
+    Converts a hex color code string to an (R, G, B) integer tuple.
+
+    Supports 3-digit and 6-digit hex color codes with or without '#'.
+
+    Args:
+        hex_code (str): Hex color string to convert (e.g., "#FFFFFF" or "fff").
+
+    Returns:
+        tuple[int, int, int]: RGB values as (r, g, b) integers in range 0-255.
+
+    Raises:
+        ValueError: If hex_code is not a valid hex color.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import hex_to_rgb
+
+            hex_to_rgb("#FFFFFF")  # -> (255, 255, 255)
+            hex_to_rgb("00ff00")  # -> (0, 255, 0)
+            ```
+
+        === "The Traditional Way"
+            ```python
+            hex_code = "#FFFFFF".lstrip("#")
+            if len(hex_code) == 3:
+                hex_code = "".join(c * 2 for c in hex_code)
+            r, g, b = tuple(int(hex_code[i : i + 2], 16) for i in (0, 2, 4))
+            ```
+    """
+    if not is_valid_hex(hex_code):
+        raise ValueError(f"Invalid hex color code: '{hex_code}'")
+
+    cleaned = hex_code.lstrip("#")
+    if len(cleaned) == 3:
+        cleaned = "".join(character * 2 for character in cleaned)
+
+    r = int(cleaned[0:2], 16)
+    g = int(cleaned[2:4], 16)
+    b = int(cleaned[4:6], 16)
+
+    return (r, g, b)
+
+
+def rgb_to_hex(r: int, g: int, b: int) -> str:
+    """
+    Converts (R, G, B) color values to a hex color string.
+
+    Args:
+        r (int): Red channel value (0 to 255).
+        g (int): Green channel value (0 to 255).
+        b (int): Blue channel value (0 to 255).
+
+    Returns:
+        str: Uppercase hex color string (e.g., "#FFFFFF").
+
+    Raises:
+        ValueError: If any channel is outside the 0-255 range.
+        TypeError: If any channel is not an integer.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import rgb_to_hex
+
+            rgb_to_hex(255, 255, 255)  # -> "#FFFFFF"
+            rgb_to_hex(0, 128, 64)  # -> "#008040"
+            ```
+
+        === "The Traditional Way"
+            ```python
+            r, g, b = 255, 255, 255
+            hex_code = f"#{r:02X}{g:02X}{b:02X}"
+            ```
+    """
+    for name, val in [("r", r), ("g", g), ("b", b)]:
+        if not isinstance(val, int) or isinstance(val, bool):
+            raise TypeError(f"Color channel '{name}' must be an integer.")
+        if not (0 <= val <= 255):
+            raise ValueError(
+                f"Color channel '{name}' must be between 0 and 255, got {val}."
+            )
+
+    return f"#{r:02X}{g:02X}{b:02X}"

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -1,0 +1,112 @@
+import pytest
+
+from py_simple_package.src.py_simple.easy_colors import (
+    hex_to_rgb,
+    is_valid_hex,
+    rgb_to_hex,
+)
+
+
+@pytest.mark.parametrize(
+    "hex_code, expected",
+    [
+        ("#FFFFFF", True),
+        ("#ffffff", True),
+        ("FFFFFF", True),
+        ("ffffff", True),
+        ("#FFF", True),
+        ("#fff", True),
+        ("FFF", True),
+        ("fff", True),
+        ("#000000", True),
+        ("#123456", True),
+        ("#abcDEF", True),
+        ("123456", True),
+        ("#GGGGGG", False),
+        ("#12345", False),
+        ("#1234567", False),
+        ("xyz", False),
+        ("", False),
+        (None, False),
+        (123456, False),
+    ],
+)
+def test_is_valid_hex(hex_code, expected):
+    assert is_valid_hex(hex_code) is expected
+
+
+@pytest.mark.parametrize(
+    "hex_code, expected",
+    [
+        ("#FFFFFF", (255, 255, 255)),
+        ("#ffffff", (255, 255, 255)),
+        ("FFFFFF", (255, 255, 255)),
+        ("#000000", (0, 0, 0)),
+        ("#00ff00", (0, 255, 0)),
+        ("#123456", (18, 52, 86)),
+        ("#FFF", (255, 255, 255)),
+        ("fff", (255, 255, 255)),
+        ("#000", (0, 0, 0)),
+        ("f0a", (255, 0, 170)),
+    ],
+)
+def test_hex_to_rgb_valid(hex_code, expected):
+    assert hex_to_rgb(hex_code) == expected
+
+
+@pytest.mark.parametrize(
+    "invalid_hex",
+    [
+        "#GGGGGG",
+        "#12345",
+        "#1234567",
+        "invalid",
+        "",
+        "1234567",
+    ],
+)
+def test_hex_to_rgb_invalid(invalid_hex):
+    with pytest.raises(ValueError):
+        hex_to_rgb(invalid_hex)
+
+
+@pytest.mark.parametrize(
+    "r, g, b, expected",
+    [
+        (255, 255, 255, "#FFFFFF"),
+        (0, 0, 0, "#000000"),
+        (0, 255, 0, "#00FF00"),
+        (18, 52, 86, "#123456"),
+        (255, 0, 170, "#FF00AA"),
+    ],
+)
+def test_rgb_to_hex_valid(r, g, b, expected):
+    assert rgb_to_hex(r, g, b) == expected
+
+
+@pytest.mark.parametrize(
+    "r, g, b",
+    [
+        (-1, 0, 0),
+        (0, 256, 0),
+        (0, 0, 300),
+        (-255, 0, 0),
+    ],
+)
+def test_rgb_to_hex_out_of_range(r, g, b):
+    with pytest.raises(ValueError):
+        rgb_to_hex(r, g, b)
+
+
+@pytest.mark.parametrize(
+    "r, g, b",
+    [
+        ("255", 255, 255),
+        (255, 255.0, 255),
+        (True, 255, 255),
+        (255, None, 255),
+    ],
+)
+def test_rgb_to_hex_invalid_types(r, g, b):
+    with pytest.raises(TypeError):
+        rgb_to_hex(r, g, b)


### PR DESCRIPTION
Resolves #40

### Changes Included:
- **`src/py_simple/easy_colors.py`**:
  - `hex_to_rgb(hex_code)`: Converts 3-digit and 6-digit hex color strings to (r, g, b) tuples.
  - `rgb_to_hex(r, g, b)`: Converts RGB integers (0-255) to upper-case #RRGGBB strings.
  - `is_valid_hex(hex_code)`: Validates 3-digit and 6-digit hex color strings with or without #.
- **Unit Tests**: Added comprehensive test cases in `tests/test_colors.py` covering valid conversions, boundary values, out-of-range inputs, and type safety (all 284 unit tests passing).
- **Documentation**: Added reference doc `docs/reference/easy_colors.md` and updated `mkdocs.yml`.