### PR TITLE
test(easy_json): add unit tests for open_json and save_json_data (fixes #47)

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,59 @@
+import json
+import pytest
+
+from py_simple_package.src.py_simple.easy_json import (
+    EasyJsonError,
+    open_json,
+    save_json_data,
+)
+
+
+class TestEasyJson:
+
+    def test_open_json_success(self, tmp_path):
+        json_file = tmp_path / "sample.json"
+        data = {"name": "Sara", "role": "Maintainer", "active": True}
+        json_file.write_text(json.dumps(data), encoding="utf-8")
+
+        result = open_json(str(json_file))
+        assert result == data
+
+    def test_open_json_missing_file_raises_easy_json_error(self, tmp_path):
+        missing_file = tmp_path / "does_not_exist.json"
+
+        with pytest.raises(EasyJsonError) as exc_info:
+            open_json(str(missing_file))
+        assert "ERROR:" in str(exc_info.value)
+
+    def test_open_json_invalid_syntax_raises_easy_json_error(self, tmp_path):
+        bad_json_file = tmp_path / "bad_syntax.json"
+        bad_json_file.write_text('{"name": "Sara",}', encoding="utf-8")
+
+        with pytest.raises(EasyJsonError) as exc_info:
+            open_json(str(bad_json_file))
+        assert "ERROR:" in str(exc_info.value)
+
+    def test_save_json_data_success(self, tmp_path):
+        json_file = tmp_path / "output.json"
+        data = {"project": "Py_simple", "version": "1.0.0"}
+
+        save_json_data(str(json_file), data)
+
+        assert json_file.exists()
+        loaded_data = json.loads(json_file.read_text(encoding="utf-8"))
+        assert loaded_data == data
+
+    def test_save_json_data_already_exists_raises_easy_json_error(self, tmp_path):
+        existing_file = tmp_path / "existing.json"
+        existing_file.write_text('{"key": "value"}', encoding="utf-8")
+
+        with pytest.raises(EasyJsonError) as exc_info:
+            save_json_data(str(existing_file), {"new_key": "new_val"})
+        assert "already exists" in str(exc_info.value)
+
+    def test_save_json_data_invalid_directory_raises_easy_json_error(self, tmp_path):
+        invalid_file = tmp_path / "non_existent_folder" / "output.json"
+
+        with pytest.raises(EasyJsonError) as exc_info:
+            save_json_data(str(invalid_file), {"key": "val"})
+        assert "ERROR:" in str(exc_info.value)


### PR DESCRIPTION
…es #47)

*********************************

Added unit tests in `tests/test_json.py` for the new `easy_json.py` module:

- **`test_open_json`**: Tests reading a valid JSON file, handling non-existent file path, and handling invalid JSON syntax (all wrapping to `EasyJsonError`).
- **`test_save_json_data`**: Tests saving dictionary data to a new JSON file, preventing overwrite on existing files (raises `EasyJsonError`), and handling invalid directory paths (raises `EasyJsonError`).

All 6 unit tests pass 100% green.

Fixes #47