### PR TITLE
feat: add round_to_nearest, greatest_common_divisor, and clamp helpers

### DIFF
--- a/py_simple_package/src/py_simple/easy_numbers.py
+++ b/py_simple_package/src/py_simple/easy_numbers.py
@@ -241,3 +241,96 @@ def percentage_of(number: int, percentage: float) -> float:
             ```
     """
     return float(f"{(number * percentage):.2f}")
+
+
+def round_to_nearest(number: float, nearest: int) -> float:
+    """
+    Returns a number rounded to the nearest multiple.
+
+    Args:
+        number (float): Number to round.
+        nearest (int): Multiple to round to.
+
+    Returns:
+        float: Rounded number.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import round_to_nearest
+
+            result = round_to_nearest(23, 5)  # -> 25.0
+            ```
+
+        === "The Traditional Way"
+            ```python
+            number, nearest = 23, 5
+            result = round(number / nearest) * nearest
+            ```
+    """
+    if nearest == 0:
+        raise ValueError("'nearest' must not be zero.")
+
+    return round(number / nearest) * nearest
+
+
+def greatest_common_divisor(a: int, b: int) -> int:
+    """
+    Returns the greatest common divisor (GCD) of two numbers.
+
+    Args:
+        a (int): First number.
+        b (int): Second number.
+
+    Returns:
+        int: Greatest common divisor.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import greatest_common_divisor
+
+            result = greatest_common_divisor(12, 18)  # -> 6
+            ```
+
+        === "The Traditional Way"
+            ```python
+            import math
+
+            a, b = 12, 18
+            result = math.gcd(a, b)
+            ```
+    """
+    while b != 0:
+        a, b = b, a % b
+
+    return abs(a)
+
+
+def clamp(number: float, minimum: float, maximum: float) -> float:
+    """
+    Keeps a number within a minimum and maximum range.
+
+    Args:
+        number (float): Number to clamp.
+        minimum (float): Minimum allowed value.
+        maximum (float): Maximum allowed value.
+
+    Returns:
+        float: Clamped number.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import clamp
+
+            result = clamp(15, 0, 10)  # -> 10
+            ```
+
+        === "The Traditional Way"
+            ```python
+            number, minimum, maximum = 15, 0, 10
+            result = max(minimum, min(number, maximum))
+            ```
+    """
+    return max(minimum, min(number, maximum))


### PR DESCRIPTION
## Summary

This PR expands the `easy_numbers` module by adding three beginner-friendly utility functions:

* `round_to_nearest(number: float, nearest: int) -> float`
* `greatest_common_divisor(a: int, b: int) -> int`
* `clamp(number: float, minimum: float, maximum: float) -> float`

## Changes

### Added `round_to_nearest`

* Rounds a number to the nearest multiple of the provided value.
* Raises a `ValueError` when `nearest` is `0` to prevent division by zero.
* Added a complete docstring with arguments, return value, and usage examples.

### Added `greatest_common_divisor`

* Implements the Euclidean algorithm to calculate the greatest common divisor of two integers.
* Returns the absolute value to ensure a non-negative GCD.
* Added comprehensive documentation and examples.

### Added `clamp`

* Restricts a number to a given minimum and maximum range.
* Returns:

  * `minimum` if the number is below the range.
  * `maximum` if the number is above the range.
  * The original number if it already lies within the range.
* Added complete documentation and examples.

## Documentation

All three functions include:

* Function description
* `Args`
* `Returns`
* Examples following the existing project format:

  * **The Py_simple Way**
  * **The Traditional Way**

The docstrings were written to match the style already used throughout the project.

## Testing

* Verified the behavior of all three functions with representative inputs.
* Confirmed expected outputs for normal and edge cases (including `nearest == 0` for `round_to_nearest`).

Close #37