### PR TITLE
feat: add count_tags, get_tag_list, and print_allowed_tags to easy_web

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ py-simple-wrap provides simple modules designed to make common Python tasks easi
 | `get_page_content(url)` | Get prettified HTML | `get_page_content("https://google.com")` |
 | `count_links(url)` | Count links on a page | `count_links("https://github.com")` → `144` |
 | `get_link_list(url)` | Get all links as a list | `get_link_list("https://github.com")` → `[...]` |
+| `count_tags(url, tag)` | Count tags of a given type (e.g. `'a'`, `'img'`) | `count_tags("https://github.com", "img")` → `12` |
+| `get_tag_list(url, tag)` | Get useful info from each matching tag | `get_tag_list("https://github.com", "img")` → `[...]` |
+| `print_allowed_tags()` | Print the supported tag → attribute map | `print_allowed_tags()` → `{'a': 'href', 'img': 'src'}` |
 | `get_meta_description(url)` | Get all meta tag contents | `get_meta_description("https://github.com")` → `[...]` |
 | `get_all_headers(url)` | Get text from all `<header>` tags | `get_all_headers("https://github.com")` → `[...]` |
 

--- a/py_simple_package/src/py_simple/__init__.py
+++ b/py_simple_package/src/py_simple/__init__.py
@@ -26,7 +26,8 @@ from .easy_validator import (
 )
 from .easy_web import (
     get_page_content, is_page_up, get_link_list, get_page_title,
-    count_links, get_all_headers, get_meta_description
+    count_links, count_tags, get_tag_list, print_allowed_tags,
+    get_all_headers, get_meta_description
 )
 from .easy_strings import (
     is_palindrome, remove_extra_spaces, to_kebab_case, to_snake_case,

--- a/py_simple_package/src/py_simple/easy_web.py
+++ b/py_simple_package/src/py_simple/easy_web.py
@@ -241,6 +241,124 @@ def get_link_list(url: str) -> list[str] | None:
         raise SomethingWentWrongError(f"\n\n\nERROR: {e}") from None
 
 
+def count_tags(url: str, tag: str) -> int | None:
+    """
+    Returns the number of tags of a given type on a page, or None if an
+    error occurs.
+
+    Raises ValueError if the tag is not in the allowed tags list
+    (see print_allowed_tags).
+
+    Args:
+        url (str): Website to count tags from.
+        tag (str): HTML tag to count (e.g. 'a', 'img').
+
+    Returns:
+        int | None: number of matching tags, or None if an error occurs.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import count_tags
+
+            print(count_tags("https://github.com", "img")) #-> 12
+            ```
+        === "The Traditional Way"
+            ```python
+            import requests
+            from bs4 import BeautifulSoup
+
+            response = requests.get(url, timeout=10)
+            soup = BeautifulSoup(response.content, 'html.parser')
+            tag_count = len(soup.find_all('img'))
+            ```
+    """
+    if tag not in _TAGS:
+        raise ValueError(
+            f"Unsupported tag: '{tag}'. Allowed tags: {', '.join(_TAGS)}"
+        )
+    try:
+        response = requests.get(url, timeout=10)
+        soup = BeautifulSoup(response.content, 'html.parser')
+        if response is not None:
+            return len(soup.find_all(tag))
+    except Exception as e:
+        raise SomethingWentWrongError(f"\n\n\nERROR: {e}") from None
+
+
+def get_tag_list(url: str, tag: str) -> list[str] | None:
+    """
+    Returns a list of the useful info from each matching tag on the page,
+    or None if an error occurs.
+
+    For `a` tags this is the link (`href`); for `img` tags it is the
+    image source (`src`). See print_allowed_tags for supported tags.
+
+    Raises ValueError if the tag is not in the allowed tags list.
+
+    Args:
+        url (str): Website to get tags from.
+        tag (str): HTML tag to list (e.g. 'a', 'img').
+
+    Returns:
+        list[str] | None: list of attribute values from matching tags,
+            or None if an error occurs.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import get_tag_list
+
+            print(get_tag_list("https://github.com", "img")) #-> ["logo.png", ...]
+            ```
+        === "The Traditional Way"
+            ```python
+            import requests
+            from bs4 import BeautifulSoup
+
+            response = requests.get(url, timeout=10)
+            soup = BeautifulSoup(response.content, 'html.parser')
+            tag_list = []
+            for tag in soup.find_all('img'):
+                tag_list.append(tag.get('src'))
+            ```
+    """
+    if tag not in _TAGS:
+        raise ValueError(
+            f"Unsupported tag: '{tag}'. Allowed tags: {', '.join(_TAGS)}"
+        )
+    try:
+        response = requests.get(url, timeout=10)
+        soup = BeautifulSoup(response.content, 'html.parser')
+        attribute = _TAGS[tag]
+        tag_list = []
+        if response is not None:
+            for element in soup.find_all(tag):
+                tag_list.append(element.get(attribute))
+            return tag_list
+    except Exception as e:
+        raise SomethingWentWrongError(f"\n\n\nERROR: {e}") from None
+
+
+def print_allowed_tags() -> None:
+    """
+    Prints the dictionary of tags supported by count_tags and get_tag_list.
+
+    Each entry maps a tag name to the attribute that get_tag_list returns
+    for that tag.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import print_allowed_tags
+
+            print_allowed_tags()
+            # {'a': 'href', 'img': 'src'}
+            ```
+    """
+    print(_TAGS)
+
+
 def get_meta_description(url: str) -> list[str] | None:
     """
     Returns a list of meta tag contents found on the page, or None if

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3,10 +3,13 @@ import pytest
 import requests
 
 from py_simple_package.src.py_simple.easy_web import (
+    count_tags,
     get_all_headers,
     get_meta_description,
     get_page_content,
+    get_tag_list,
     is_page_up,
+    print_allowed_tags,
     SomethingWentWrongError,
 )
 
@@ -150,3 +153,127 @@ class TestEasyWeb:
         with pytest.raises(SomethingWentWrongError):
             get_all_headers("https://offline-site.com")
         mock_get.assert_called_once_with("https://offline-site.com", timeout=10)
+
+
+class TestCountTags:
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_count_tags_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = (
+            b'<html><body>'
+            b'<a href="/one">One</a>'
+            b'<a href="/two">Two</a>'
+            b'<a href="/three">Three</a>'
+            b'<img src="logo.png">'
+            b'</body></html>'
+        )
+        mock_get.return_value = mock_response
+
+        result = count_tags("https://example.com", "a")
+        assert result == 3
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_count_tags_img(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = (
+            b'<html><body>'
+            b'<img src="logo.png">'
+            b'<img src="banner.png">'
+            b'</body></html>'
+        )
+        mock_get.return_value = mock_response
+
+        result = count_tags("https://example.com", "img")
+        assert result == 2
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_count_tags_none_found(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = b'<html><body><p>No links here</p></body></html>'
+        mock_get.return_value = mock_response
+
+        result = count_tags("https://example.com", "a")
+        assert result == 0
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    def test_count_tags_unsupported_tag(self):
+        with pytest.raises(ValueError, match="Unsupported tag"):
+            count_tags("https://example.com", "div")
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_count_tags_exception(self, mock_get):
+        mock_get.side_effect = requests.RequestException("Network Error")
+
+        with pytest.raises(SomethingWentWrongError):
+            count_tags("https://invalid-url.com", "a")
+        mock_get.assert_called_once_with("https://invalid-url.com", timeout=10)
+
+
+class TestGetTagList:
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_tag_list_hrefs(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = (
+            b'<html><body>'
+            b'<a href="/one">One</a>'
+            b'<a href="/two">Two</a>'
+            b'<img src="logo.png">'
+            b'</body></html>'
+        )
+        mock_get.return_value = mock_response
+
+        result = get_tag_list("https://example.com", "a")
+        assert result == ["/one", "/two"]
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_tag_list_srcs(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = (
+            b'<html><body>'
+            b'<img src="logo.png">'
+            b'<img src="banner.png">'
+            b'<a href="/one">One</a>'
+            b'</body></html>'
+        )
+        mock_get.return_value = mock_response
+
+        result = get_tag_list("https://example.com", "img")
+        assert result == ["logo.png", "banner.png"]
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_tag_list_none_found(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = b'<html><body><p>No images</p></body></html>'
+        mock_get.return_value = mock_response
+
+        result = get_tag_list("https://example.com", "img")
+        assert result == []
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    def test_get_tag_list_unsupported_tag(self):
+        with pytest.raises(ValueError, match="Unsupported tag"):
+            get_tag_list("https://example.com", "script")
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_tag_list_exception(self, mock_get):
+        mock_get.side_effect = requests.RequestException("Timeout")
+
+        with pytest.raises(SomethingWentWrongError):
+            get_tag_list("https://invalid-url.com", "a")
+        mock_get.assert_called_once_with("https://invalid-url.com", timeout=10)
+
+
+class TestPrintAllowedTags:
+
+    def test_print_allowed_tags(self, capsys):
+        result = print_allowed_tags()
+        captured = capsys.readouterr()
+        assert "'a': 'href'" in captured.out
+        assert "'img': 'src'" in captured.out
+        assert result is None


### PR DESCRIPTION
## Summary
- Add `count_tags(url, tag)` — counts how many tags of a chosen type are on a page
- Add `get_tag_list(url, tag)` — returns the useful attribute (`href` for `a`, `src` for `img`) from each matching tag, driven by the `_TAGS` registry
- Add `print_allowed_tags()` — prints the supported tag → attribute map so users don't have to guess
- Unsupported tags raise `ValueError` listing the allowed tags
- Export all three from the package `__init__.py`
- README function table updated

Closes #35

## Test Results
```
321 passed in 0.54s
```

## Files Changed
| File | Δ | What |
|---|---|---|
| py_simple_package/src/py_simple/easy_web.py | +118 | 3 new functions + docstrings |
| tests/test_web.py | +127 | 11 new tests (count/list for a+img, empty pages, unsupported tags, request failures) |
| py_simple_package/src/py_simple/__init__.py | +3/-1 | export new functions |
| README.md | +3 | function table entries |