### PR TITLE
Added unit tests for easy_regex.py module

### DIFF
--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -9,7 +9,7 @@ from py_simple_package.src.py_simple.easy_colors import (
 
 @pytest.mark.parametrize(
     "hex_code, expected",
-    [()
+    [
         ("#FFFFFF", True),
         ("#ffffff", True),
         ("FFFFFF", True),

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -9,7 +9,7 @@ from py_simple_package.src.py_simple.easy_colors import (
 
 @pytest.mark.parametrize(
     "hex_code, expected",
-    [
+    [()
         ("#FFFFFF", True),
         ("#ffffff", True),
         ("FFFFFF", True),

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -7,9 +7,60 @@ from py_simple_package.src.py_simple.easy_regex import (
 
 import pytest
 
+# email test
 @pytest.mark.parametrize(
     "input_text, expected",
     [
-        ("this is my address, ginny@gmail.com", True)
+        ("this is my address, ginny@gmail.com", ["ginny@gmail.com"]),
+        ("this has no address right?",[]),
+        ("what about more than one with hello@example.com and support@test.org",['hello@example.com','support@test.org']),
+        ("a curveball to try test%123@domain.com",['test%123@domain.com']),
+        ("will.this.work@test.edu",['will.this.work@test.edu'])
+    ]
+
+)
+
+def test_is_email_extracted(input_text,expected):
+    assert extract_emails(input_text) == expected
+
+# url test
+@pytest.mark.parametrize(
+    "input_text, expected",
+    [
+        ("visit https://www.example.com or www.test.org today", ['https://www.example.com','www.test.org']),
+        ("visit test.edu today", []),
+        ("yourself http://127.0.0.1", []),
+        ("explore www.test14-maps.com", ['www.test14-maps.com']),
+        ("for longer url: http:/test.org/example", ['http:/test.org/example'])
     ]
 )
+
+def test_is_url_extracted(input_text, expected):
+    assert extract_urls(input_text) == expected
+
+# number sequence test
+@pytest.mark.parametrize(
+    "input_text, expected",
+    [
+        ("Server 192.168.1.1 logged in at 14:32 on 04-08-2026", ['192.168.1.1', '14:32', '04-08-2026']),
+        ("Python 3.14.6", ['3.14.6']),
+        ("call me at 929_759_0263", ['929_759_0263']),
+
+    ]
+)
+
+def test_is_number_sequence_extracted(input_text, expected):
+    assert extract_number_sequences(input_text) == expected
+
+# number test
+@pytest.mark.parametrize(
+    "input_text, expected",
+    [
+        ("I have 3 cats and 12 fish", ['3','12']),
+        ("this is one and this 1 too", ['1']),
+
+    ]
+)
+
+def test_is_number_extracted(input_text,expected):
+    assert extract_numbers(input_text) == expected

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,0 +1,15 @@
+from py_simple_package.src.py_simple.easy_regex import (
+    extract_emails,
+    extract_urls,
+    extract_number_sequences,
+    extract_numbers
+)
+
+import pytest
+
+@pytest.mark.parametrize(
+    "input_text, expected",
+    [
+        ("this is my address, ginny@gmail.com", True)
+    ]
+)


### PR DESCRIPTION
Good day, I hope I went about contributing to this the right way as this is my first time. I wrote a couple of tests for each of the functions in your easy_regex.py module. I only had two conditions fail during testing:

'test%[123@domain.com](mailto:123@domain.com)' - I expected this to extract the email address but the test failed for this.
'http:/test.org/example' - I expected this to handle longer url for multi-page sites but it failed for this also.
Everything else however went through without a hitch. If more test conditions are needed please do let me know and I can add those. Regardless, thank you for the learning opportunity and it was fun contributing to your codebase!