### PR TITLE
feat: add easy_lists and easy_text modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,29 @@ py-simple-wrap provides simple modules designed to make common Python tasks easi
 
 </details>
 
+### 📋 Easy Lists
+
+<details>
+<summary>Click to expand — list helpers that keep your code short and readable</summary>
+
+<br>
+
+|-----------------------------------|------------------------------------------|------------------------------------------------------------|
+| Function                          | What it does                             | Example                                                    |
+| `unique_items(items)`             | Remove duplicates, keeping order         | `unique_items([1, 2, 2, 3])` → `[1, 2, 3]`                 |
+| `find_duplicates(items)`          | Find items that appear more than once    | `find_duplicates([1, 2, 2, 3, 3, 3])` → `[2, 3]`           |
+| `chunk_list(items, size)`         | Split a list into smaller lists          | `chunk_list([1, 2, 3, 4, 5], 2)` → `[[1, 2], [3, 4], [5]]` |
+| `flatten_list(items)`             | Flatten nested lists one level deep      | `flatten_list([[1, 2], [3]])` → `[1, 2, 3]`                |
+| `most_common_item(items)`         | Find the most frequent item              | `most_common_item([1, 1, 2])` → `1`                        |
+| `rotate_list(items, steps)`       | Rotate items to the right                | `rotate_list([1, 2, 3], 1)` → `[3, 1, 2]`                  |
+| `merge_lists(list_a, list_b)`     | Combine two lists                        | `merge_lists([1, 2], [3, 4])` → `[1, 2, 3, 4]`             |
+| `alternate_lists(list_a, list_b)` | Combine lists by taking turns            | `alternate_lists([1, 2], [3, 4])` → `[1, 3, 2, 4]`         |
+| `sum_all(items)`                  | Add up numbers, even in nested lists     | `sum_all([1, [2, 3], 4])` → `10`                           |
+| `sort_numbers(items)`             | Sort numbers smallest to largest         | `sort_numbers([3, 1, 2])` → `[1, 2, 3]`                    |
+| `sort_words(items)`               | Sort words alphabetically, ignoring case | `sort_words(["banana", "Apple"])` → `["Apple", "banana"]`  |
+
+</details>
+
 ### 🔤 Easy Strings
 
 <details>
@@ -151,6 +174,28 @@ py-simple-wrap provides simple modules designed to make common Python tasks easi
 | `is_palindrome(text)`       | Check if text reads the same backwards     | `is_palindrome("Never odd or even")` → `True`                |
 | `is_alphanumeric(text)`     | Check if text is letters and numbers only  | `is_alphanumeric("Something123")` → `True`                   |
 | `count_words(text)`         | Count the number of words                  | `count_words("Hello world! How are you?")` → `5`             |
+
+</details>
+
+### ✂️ Easy Text
+
+<details>
+<summary>Click to expand — text formatting helpers that read like English</summary>
+
+<br>
+
+|------------------------------|---------------------------------------------|---------------------------------------------------------------|
+| Function                     | What it does                                | Example                                                       |
+| `truncate(text, length)`     | Shorten text and add an ellipsis            | `truncate("Hello world!", 5)` → `"Hello…"`                    |
+| `remove_punctuation(text)`   | Strip punctuation, keep letters and numbers | `remove_punctuation("Hello, world!")` → `"Hello world"`       |
+| `reverse_words(text)`        | Reverse the order of words                  | `reverse_words("Hello world")` → `"world Hello"`              |
+| `capitalize_title(text)`     | Capitalize the first letter of each word    | `capitalize_title("the great gatsby")` → `"The Great Gatsby"` |
+| `count_letters(text)`        | Count the number of letters                 | `count_letters("Hello 123!")` → `5`                           |
+| `count_digits(text)`         | Count the number of digits                  | `count_digits("Hello 123!")` → `3`                            |
+| `mask_part(text, visible=4)` | Hide part of text behind asterisks          | `mask_part("1234567890", 4)` → `"1234 ******"`                |
+| `pluralize(word, count)`     | Get the singular or plural form             | `pluralize("cat", 3)` → `"cats"`                              |
+| `extract_hashtags(text)`     | Extract hashtags without the # symbol       | `extract_hashtags("#python rocks")` → `["python"]`            |
+| `word_frequency(text)`       | Count how often each word appears           | `word_frequency("the cat and the dog")` → `{"the": 2, ...}`   |
 
 </details>
 

--- a/docs/reference/easy_lists.md
+++ b/docs/reference/easy_lists.md
@@ -1,0 +1,1 @@
+::: py_simple.easy_lists

--- a/docs/reference/easy_text.md
+++ b/docs/reference/easy_text.md
@@ -1,0 +1,1 @@
+::: py_simple.easy_text

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,9 @@ nav:
       - Contributing: how-to/contributing.md
   - Reference:
       - Easy Numbers: reference/easy_numbers.md
+      - Easy Lists: reference/easy_lists.md
       - Easy Strings: reference/easy_strings.md
+      - Easy Text: reference/easy_text.md
       - Easy Colors: reference/easy_colors.md
       - Easy Web: reference/easy_web.md
       - Easy Json: reference/easy_json.md

--- a/py_simple_package/src/py_simple/__init__.py
+++ b/py_simple_package/src/py_simple/__init__.py
@@ -52,3 +52,13 @@ from .easy_regex import (
 from .easy_async import (
     run_at_the_same_time_no_params, run_at_the_same_time_with_params,
 )
+from .easy_lists import (
+    unique_items, find_duplicates, chunk_list, flatten_list,
+    most_common_item, rotate_list, merge_lists, alternate_lists,
+    sum_all, sort_numbers, sort_words,
+)
+from .easy_text import (
+    truncate, remove_punctuation, reverse_words, capitalize_title,
+    count_letters, count_digits, mask_part, pluralize, extract_hashtags,
+    word_frequency,
+)

--- a/py_simple_package/src/py_simple/easy_lists.py
+++ b/py_simple_package/src/py_simple/easy_lists.py
@@ -1,0 +1,349 @@
+"""Beginner-friendly helpers for common list operations."""
+
+
+def unique_items(items: list) -> list:
+    """
+    Returns a new list with duplicates removed, keeping the original order.
+
+    Args:
+        items (list): List that may contain duplicates.
+
+    Returns:
+        list: List with duplicates removed, order preserved.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import unique_items
+
+            result = unique_items([1, 2, 2, 3])  # -> [1, 2, 3]
+            ```
+
+        === "The Traditional Way"
+            ```python
+            items = [1, 2, 2, 3]
+            result = []
+            for item in items:
+                if item not in result:
+                    result.append(item)
+            ```
+    """
+    return list(dict.fromkeys(items))
+
+
+def find_duplicates(items: list) -> list:
+    """
+    Returns a list of items that appear more than once.
+
+    Args:
+        items (list): List to check for duplicates.
+
+    Returns:
+        list: Duplicated items, in the order they first appear.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import find_duplicates
+
+            result = find_duplicates([1, 2, 2, 3, 3, 3])  # -> [2, 3]
+            ```
+
+        === "The Traditional Way"
+            ```python
+            items = [1, 2, 2, 3, 3, 3]
+            result = list({item for item in items if items.count(item) > 1})
+            ```
+    """
+    seen = set()
+    duplicates = []
+    for item in items:
+        if item in seen:
+            if item not in duplicates:
+                duplicates.append(item)
+        else:
+            seen.add(item)
+    return duplicates
+
+
+def chunk_list(items: list, size: int) -> list:
+    """
+    Splits a list into smaller lists of the given size.
+
+    Args:
+        items (list): List to split.
+        size (int): Maximum size of each chunk.
+
+    Returns:
+        list: List of chunks.
+
+    Raises:
+        ValueError: If size is less than 1.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import chunk_list
+
+            result = chunk_list([1, 2, 3, 4, 5], 2)  # -> [[1, 2], [3, 4], [5]]
+            ```
+
+        === "The Traditional Way"
+            ```python
+            items, size = [1, 2, 3, 4, 5], 2
+            result = [items[i:i + size] for i in range(0, len(items), size)]
+            ```
+    """
+    if size < 1:
+        raise ValueError("'size' must be at least 1.")
+
+    return [items[i:i + size] for i in range(0, len(items), size)]
+
+
+def flatten_list(items: list) -> list:
+    """
+    Flattens a list with nested lists into a single-level list.
+
+    Args:
+        items (list): List that may contain nested lists.
+
+    Returns:
+        list: Flattened list, one level deep.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import flatten_list
+
+            result = flatten_list([[1, 2], [3]])  # -> [1, 2, 3]
+            ```
+
+        === "The Traditional Way"
+            ```python
+            items = [[1, 2], [3]]
+            result = [item for sublist in items for item in sublist]
+            ```
+    """
+    flattened = []
+    for item in items:
+        if isinstance(item, list):
+            flattened.extend(item)
+        else:
+            flattened.append(item)
+    return flattened
+
+
+def most_common_item(items: list) -> object:
+    """
+    Returns the item that appears most often in a list.
+
+    Args:
+        items (list): List to examine.
+
+    Returns:
+        object: The most frequent item.
+
+    Raises:
+        ValueError: If the list is empty.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import most_common_item
+
+            result = most_common_item([1, 1, 2])  # -> 1
+            ```
+
+        === "The Traditional Way"
+            ```python
+            from collections import Counter
+
+            items = [1, 1, 2]
+            result = Counter(items).most_common(1)[0][0]
+            ```
+    """
+    if not items:
+        raise ValueError("Cannot find the most common item of an empty list.")
+
+    return max(set(items), key=items.count)
+
+
+def rotate_list(items: list, steps: int) -> list:
+    """
+    Rotates a list to the right by the given number of steps.
+
+    Negative steps rotate to the left.
+
+    Args:
+        items (list): List to rotate.
+        steps (int): Number of positions to rotate.
+
+    Returns:
+        list: Rotated list.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import rotate_list
+
+            result = rotate_list([1, 2, 3], 1)  # -> [3, 1, 2]
+            ```
+
+        === "The Traditional Way"
+            ```python
+            items, steps = [1, 2, 3], 1
+            steps = steps % len(items)
+            result = items[-steps:] + items[:-steps]
+            ```
+    """
+    if not items:
+        return []
+
+    steps = steps % len(items)
+    return items[-steps:] + items[:-steps]
+
+
+def merge_lists(list_a: list, list_b: list) -> list:
+    """
+    Combines two lists into one.
+
+    Args:
+        list_a (list): First list.
+        list_b (list): Second list.
+
+    Returns:
+        list: Combined list, list_b items after list_a items.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import merge_lists
+
+            result = merge_lists([1, 2], [3, 4])  # -> [1, 2, 3, 4]
+            ```
+
+        === "The Traditional Way"
+            ```python
+            list_a, list_b = [1, 2], [3, 4]
+            result = list_a + list_b
+            ```
+    """
+    return list_a + list_b
+
+
+def alternate_lists(list_a: list, list_b: list) -> list:
+    """
+    Combines two lists by taking turns, one item at a time.
+
+    Args:
+        list_a (list): First list.
+        list_b (list): Second list.
+
+    Returns:
+        list: Alternating list, remaining items appended at the end.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import alternate_lists
+
+            result = alternate_lists([1, 2], [3, 4])  # -> [1, 3, 2, 4]
+            ```
+
+        === "The Traditional Way"
+            ```python
+            list_a, list_b = [1, 2], [3, 4]
+            result = [item for pair in zip(list_a, list_b) for item in pair]
+            ```
+    """
+    alternated = []
+    for first, second in zip(list_a, list_b):
+        alternated.append(first)
+        alternated.append(second)
+    alternated.extend(list_a[len(list_b):])
+    alternated.extend(list_b[len(list_a):])
+    return alternated
+
+
+def sum_all(items: list) -> int:
+    """
+    Adds up every number in a list, including numbers inside nested lists.
+
+    Args:
+        items (list): List of numbers, possibly with nested lists.
+
+    Returns:
+        int: Total of all numbers.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import sum_all
+
+            result = sum_all([1, [2, 3], 4])  # -> 10
+            ```
+
+        === "The Traditional Way"
+            ```python
+            items = [1, [2, 3], 4]
+            result = sum(item for sublist in items
+                         for item in (sublist if isinstance(sublist, list)
+                                      else [sublist]))
+            ```
+    """
+    return sum(flatten_list(items))
+
+
+def sort_numbers(items: list) -> list:
+    """
+    Returns a new list of numbers sorted from smallest to largest.
+
+    Args:
+        items (list): List of numbers.
+
+    Returns:
+        list: Sorted list of numbers.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import sort_numbers
+
+            result = sort_numbers([3, 1, 2])  # -> [1, 2, 3]
+            ```
+
+        === "The Traditional Way"
+            ```python
+            items = [3, 1, 2]
+            result = sorted(items)
+            ```
+    """
+    return sorted(items)
+
+
+def sort_words(items: list) -> list:
+    """
+    Returns a new list of words sorted alphabetically, ignoring case.
+
+    Args:
+        items (list): List of words.
+
+    Returns:
+        list: Sorted list of words.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import sort_words
+
+            result = sort_words(["banana", "Apple", "cherry"])
+            # -> ["Apple", "banana", "cherry"]
+            ```
+
+        === "The Traditional Way"
+            ```python
+            items = ["banana", "Apple", "cherry"]
+            result = sorted(items, key=str.lower)
+            ```
+    """
+    return sorted(items, key=str.lower)

--- a/py_simple_package/src/py_simple/easy_text.py
+++ b/py_simple_package/src/py_simple/easy_text.py
@@ -1,0 +1,304 @@
+"""Beginner-friendly helpers for common text formatting and cleaning."""
+
+import re
+
+
+def truncate(text: str, length: int) -> str:
+    """
+    Shortens text to the given length and adds an ellipsis character.
+
+    Args:
+        text (str): Text to shorten.
+        length (int): Maximum number of characters to keep.
+
+    Returns:
+        str: Shortened text, or the original text if it is short enough.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import truncate
+
+            result = truncate("Hello world!", 5)  # -> "Hello…"
+            ```
+
+        === "The Traditional Way"
+            ```python
+            text, length = "Hello world!", 5
+            result = text[:length] + "…" if len(text) > length else text
+            ```
+    """
+    if len(text) <= length:
+        return text
+    return text[:length] + "…"
+
+
+def remove_punctuation(text: str) -> str:
+    """
+    Removes punctuation from text, keeping letters, numbers, and spaces.
+
+    Args:
+        text (str): Text to clean.
+
+    Returns:
+        str: Text without punctuation.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import remove_punctuation
+
+            result = remove_punctuation("Hello, world!")  # -> "Hello world"
+            ```
+
+        === "The Traditional Way"
+            ```python
+            import string
+
+            text = "Hello, world!"
+            result = "".join(c for c in text if c not in string.punctuation)
+            ```
+    """
+    return "".join(
+        character for character in text
+        if character.isalnum() or character.isspace()
+    )
+
+
+def reverse_words(text: str) -> str:
+    """
+    Reverses the order of words in text.
+
+    Args:
+        text (str): Text to reverse.
+
+    Returns:
+        str: Text with words in reverse order.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import reverse_words
+
+            result = reverse_words("Hello world")  # -> "world Hello"
+            ```
+
+        === "The Traditional Way"
+            ```python
+            text = "Hello world"
+            result = " ".join(text.split()[::-1])
+            ```
+    """
+    return " ".join(text.split()[::-1])
+
+
+def capitalize_title(text: str) -> str:
+    """
+    Capitalizes the first letter of every word in text.
+
+    Args:
+        text (str): Text to capitalize.
+
+    Returns:
+        str: Text with every word capitalized.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import capitalize_title
+
+            result = capitalize_title("the great gatsby")  # -> "The Great Gatsby"
+            ```
+
+        === "The Traditional Way"
+            ```python
+            text = "the great gatsby"
+            result = text.title()
+            ```
+    """
+    return text.title()
+
+
+def count_letters(text: str) -> int:
+    """
+    Counts the number of letters in text.
+
+    Args:
+        text (str): Text to count.
+
+    Returns:
+        int: Number of letters (a-z, A-Z, and accented letters).
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import count_letters
+
+            result = count_letters("Hello 123!")  # -> 5
+            ```
+
+        === "The Traditional Way"
+            ```python
+            text = "Hello 123!"
+            result = sum(1 for c in text if c.isalpha())
+            ```
+    """
+    return sum(1 for character in text if character.isalpha())
+
+
+def count_digits(text: str) -> int:
+    """
+    Counts the number of digits in text.
+
+    Args:
+        text (str): Text to count.
+
+    Returns:
+        int: Number of digits (0-9).
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import count_digits
+
+            result = count_digits("Hello 123!")  # -> 3
+            ```
+
+        === "The Traditional Way"
+            ```python
+            text = "Hello 123!"
+            result = sum(1 for c in text if c.isdigit())
+            ```
+    """
+    return sum(1 for character in text if character.isdigit())
+
+
+def mask_part(text: str, visible: int = 4) -> str:
+    """
+    Hides part of text (like a card number) behind asterisks.
+
+    The first `visible` characters stay visible, the rest are masked.
+
+    Args:
+        text (str): Text to mask.
+        visible (int): Number of characters to keep visible. Defaults to 4.
+
+    Returns:
+        str: Masked text.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import mask_part
+
+            result = mask_part("1234567890", 4)  # -> "1234 ******"
+            ```
+
+        === "The Traditional Way"
+            ```python
+            text, visible = "1234567890", 4
+            result = text[:visible] + " " + "*" * len(text[visible:])
+            ```
+    """
+    if visible >= len(text):
+        return text
+    return text[:visible] + " " + "*" * len(text[visible:])
+
+
+def pluralize(word: str, count: int) -> str:
+    """
+    Returns the singular or plural form of a word based on the count.
+
+    Args:
+        word (str): Word to pluralize.
+        count (int): Number of items.
+
+    Returns:
+        str: Singular word if count is 1, plural word otherwise.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import pluralize
+
+            result = pluralize("cat", 3)  # -> "cats"
+            ```
+
+        === "The Traditional Way"
+            ```python
+            word, count = "cat", 3
+            result = word if count == 1 else word + "s"
+            ```
+    """
+    if count == 1:
+        return word
+    if word.endswith("s"):
+        return word + "es"
+    return word + "s"
+
+
+def extract_hashtags(text: str) -> list:
+    """
+    Extracts all hashtags from text, without the # symbol.
+
+    Args:
+        text (str): Text to search.
+
+    Returns:
+        list: Hashtag words found in the text.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import extract_hashtags
+
+            result = extract_hashtags("Loving #python and #coding!")
+            # -> ["python", "coding"]
+            ```
+
+        === "The Traditional Way"
+            ```python
+            import re
+
+            text = "Loving #python and #coding!"
+            result = re.findall(r"#(\\w+)", text)
+            ```
+    """
+    return re.findall(r"#(\w+)", text)
+
+
+def word_frequency(text: str) -> dict:
+    """
+    Counts how often each word appears in text.
+
+    Punctuation is ignored and words are counted in lowercase.
+
+    Args:
+        text (str): Text to analyze.
+
+    Returns:
+        dict: Word counts, keyed by word.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import word_frequency
+
+            result = word_frequency("the cat and the dog")
+            # -> {"the": 2, "cat": 1, "and": 1, "dog": 1}
+            ```
+
+        === "The Traditional Way"
+            ```python
+            import re
+            from collections import Counter
+
+            text = "the cat and the dog"
+            words = re.sub(r"[^\\w\\s]", "", text).lower().split()
+            result = dict(Counter(words))
+            ```
+    """
+    frequency = {}
+    for word in remove_punctuation(text).lower().split():
+        frequency[word] = frequency.get(word, 0) + 1
+    return frequency

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -1,0 +1,171 @@
+import pytest
+
+from py_simple_package.src.py_simple.easy_lists import (
+    alternate_lists,
+    chunk_list,
+    find_duplicates,
+    flatten_list,
+    merge_lists,
+    most_common_item,
+    rotate_list,
+    sort_numbers,
+    sort_words,
+    sum_all,
+    unique_items,
+)
+
+
+@pytest.mark.parametrize(
+    "items, expected",
+    [
+        ([1, 2, 2, 3], [1, 2, 3]),
+        (["a", "b", "a", "c"], ["a", "b", "c"]),
+        ([1, 1, 1], [1]),
+        ([], []),
+    ],
+)
+def test_unique_items(items, expected):
+    assert unique_items(items) == expected
+
+
+@pytest.mark.parametrize(
+    "items, expected",
+    [
+        ([1, 2, 2, 3, 3, 3], [2, 3]),
+        ([1, 2, 3], []),
+        (["a", "b", "a"], ["a"]),
+        ([], []),
+    ],
+)
+def test_find_duplicates(items, expected):
+    assert find_duplicates(items) == expected
+
+
+@pytest.mark.parametrize(
+    "items, size, expected",
+    [
+        ([1, 2, 3, 4, 5], 2, [[1, 2], [3, 4], [5]]),
+        ([1, 2, 3], 5, [[1, 2, 3]]),
+        ([1, 2, 3, 4], 2, [[1, 2], [3, 4]]),
+        ([], 3, []),
+    ],
+)
+def test_chunk_list(items, size, expected):
+    assert chunk_list(items, size) == expected
+
+
+@pytest.mark.parametrize("size", [0, -1, -5])
+def test_chunk_list_rejects_invalid_size(size):
+    with pytest.raises(ValueError):
+        chunk_list([1, 2, 3], size)
+
+
+@pytest.mark.parametrize(
+    "items, expected",
+    [
+        ([[1, 2], [3]], [1, 2, 3]),
+        ([1, [2, 3], 4], [1, 2, 3, 4]),
+        ([[], [1]], [1]),
+        ([], []),
+    ],
+)
+def test_flatten_list(items, expected):
+    assert flatten_list(items) == expected
+
+
+@pytest.mark.parametrize(
+    "items, expected",
+    [
+        ([1, 1, 2], 1),
+        (["a", "b", "b"], "b"),
+        ([7], 7),
+    ],
+)
+def test_most_common_item(items, expected):
+    assert most_common_item(items) == expected
+
+
+def test_most_common_item_rejects_empty_list():
+    with pytest.raises(ValueError):
+        most_common_item([])
+
+
+@pytest.mark.parametrize(
+    "items, steps, expected",
+    [
+        ([1, 2, 3], 1, [3, 1, 2]),
+        ([1, 2, 3], -1, [2, 3, 1]),
+        ([1, 2, 3], 3, [1, 2, 3]),
+        ([1, 2, 3, 4], 2, [3, 4, 1, 2]),
+        ([1, 2, 3], 4, [3, 1, 2]),
+        ([], 1, []),
+    ],
+)
+def test_rotate_list(items, steps, expected):
+    assert rotate_list(items, steps) == expected
+
+
+@pytest.mark.parametrize(
+    "list_a, list_b, expected",
+    [
+        ([1, 2], [3, 4], [1, 2, 3, 4]),
+        (["a"], ["b", "c"], ["a", "b", "c"]),
+        ([], [1], [1]),
+        ([], [], []),
+    ],
+)
+def test_merge_lists(list_a, list_b, expected):
+    assert merge_lists(list_a, list_b) == expected
+
+
+@pytest.mark.parametrize(
+    "list_a, list_b, expected",
+    [
+        ([1, 2], [3, 4], [1, 3, 2, 4]),
+        ([1, 2, 3], [4], [1, 4, 2, 3]),
+        (["a"], ["x", "y"], ["a", "x", "y"]),
+        ([], [1, 2], [1, 2]),
+        ([], [], []),
+    ],
+)
+def test_alternate_lists(list_a, list_b, expected):
+    assert alternate_lists(list_a, list_b) == expected
+
+
+@pytest.mark.parametrize(
+    "items, expected",
+    [
+        ([1, 2, 3], 6),
+        ([1, [2, 3], 4], 10),
+        ([1.5, 2.5], 4.0),
+        ([], 0),
+    ],
+)
+def test_sum_all(items, expected):
+    assert sum_all(items) == expected
+
+
+@pytest.mark.parametrize(
+    "items, expected",
+    [
+        ([3, 1, 2], [1, 2, 3]),
+        ([3.5, 1.2], [1.2, 3.5]),
+        ([-1, 5, -3], [-3, -1, 5]),
+        ([], []),
+    ],
+)
+def test_sort_numbers(items, expected):
+    assert sort_numbers(items) == expected
+
+
+@pytest.mark.parametrize(
+    "items, expected",
+    [
+        (["banana", "Apple", "cherry"], ["Apple", "banana", "cherry"]),
+        (["Zebra", "apple", "mango"], ["apple", "mango", "Zebra"]),
+        (["a", "a"], ["a", "a"]),
+        ([], []),
+    ],
+)
+def test_sort_words(items, expected):
+    assert sort_words(items) == expected

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,149 @@
+import pytest
+
+from py_simple_package.src.py_simple.easy_text import (
+    capitalize_title,
+    count_digits,
+    count_letters,
+    extract_hashtags,
+    mask_part,
+    pluralize,
+    remove_punctuation,
+    reverse_words,
+    truncate,
+    word_frequency,
+)
+
+
+@pytest.mark.parametrize(
+    "text, length, expected",
+    [
+        ("Hello world!", 5, "Hello…"),
+        ("Hi", 5, "Hi"),
+        ("12345", 5, "12345"),
+        ("abcdef", 3, "abc…"),
+        ("", 3, ""),
+    ],
+)
+def test_truncate(text, length, expected):
+    assert truncate(text, length) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("Hello, world!", "Hello world"),
+        ("No punctuation here", "No punctuation here"),
+        ("don't stop", "dont stop"),
+        ("", ""),
+    ],
+)
+def test_remove_punctuation(text, expected):
+    assert remove_punctuation(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("Hello world", "world Hello"),
+        ("one", "one"),
+        ("a b c", "c b a"),
+        ("", ""),
+    ],
+)
+def test_reverse_words(text, expected):
+    assert reverse_words(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("the great gatsby", "The Great Gatsby"),
+        ("hello WORLD", "Hello World"),
+        ("", ""),
+    ],
+)
+def test_capitalize_title(text, expected):
+    assert capitalize_title(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("Hello 123!", 5),
+        ("abc", 3),
+        ("!!!", 0),
+        ("", 0),
+    ],
+)
+def test_count_letters(text, expected):
+    assert count_letters(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("Hello 123!", 3),
+        ("abc", 0),
+        ("007", 3),
+        ("", 0),
+    ],
+)
+def test_count_digits(text, expected):
+    assert count_digits(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text, visible, expected",
+    [
+        ("1234567890", 4, "1234 ******"),
+        ("1234567890", 2, "12 ********"),
+        ("1234", 4, "1234"),
+        ("abc", 10, "abc"),
+        ("", 0, ""),
+    ],
+)
+def test_mask_part(text, visible, expected):
+    assert mask_part(text, visible) == expected
+
+
+def test_mask_part_default_visible():
+    assert mask_part("1234567890") == "1234 ******"
+
+
+@pytest.mark.parametrize(
+    "word, count, expected",
+    [
+        ("cat", 1, "cat"),
+        ("cat", 3, "cats"),
+        ("dog", 0, "dogs"),
+        ("bus", 2, "buses"),
+        ("class", 2, "classes"),
+    ],
+)
+def test_pluralize(word, count, expected):
+    assert pluralize(word, count) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("Loving #python and #coding!", ["python", "coding"]),
+        ("no tags here", []),
+        ("#one #two #one", ["one", "two", "one"]),
+        ("", []),
+    ],
+)
+def test_extract_hashtags(text, expected):
+    assert extract_hashtags(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("the cat and the dog", {"the": 2, "cat": 1, "and": 1, "dog": 1}),
+        ("Hello hello", {"hello": 2}),
+        ("", {}),
+    ],
+)
+def test_word_frequency(text, expected):
+    assert word_frequency(text) == expected


### PR DESCRIPTION
## Summary

Two new beginner-friendly modules, straight from the module idea thread in #30:

- **📋 `easy_lists`** — 11 list helpers that keep code short: `unique_items`, `find_duplicates`, `chunk_list`, `flatten_list`, `most_common_item`, `rotate_list`, `merge_lists`, `alternate_lists`, `sum_all` (works on nested lists too), `sort_numbers`, `sort_words`.
- **✂️ `easy_text`** — 10 text formatting helpers: `truncate`, `remove_punctuation`, `reverse_words`, `capitalize_title`, `count_letters`, `count_digits`, `mask_part`, `pluralize`, `extract_hashtags`, `word_frequency`.

Both modules are stdlib-only, follow the existing Google-style docstring convention (Py_simple Way / Traditional Way examples), and are exported from the package root — `from py_simple import unique_items` just works.

## What's included

- New modules + package-root exports
- 30 new parametrized test cases (18 for lists, 12 for text) covering edge cases: empty inputs, negative rotation, invalid chunk sizes, nested sums, default mask visibility
- README module menu entries, mkdocstrings reference pages, and mkdocs nav entries
- `mkdocs build` verified locally — no new griffe/pylint warnings

## Test Results

```
460 passed in 0.59s
```

## Files Changed

| File | Δ | What |
|---|---|---|
| `py_simple_package/src/py_simple/easy_lists.py` | +349 | New module: 11 list helpers |
| `py_simple_package/src/py_simple/easy_text.py` | +304 | New module: 10 text helpers |
| `py_simple_package/src/py_simple/__init__.py` | +10 | Package-root exports |
| `tests/test_lists.py` | +171 | 18 parametrized test cases |
| `tests/test_text.py` | +149 | 12 parametrized test cases |
| `README.md` | +45 | Module menu sections |
| `docs/reference/easy_lists.md` | +1 | Reference page |
| `docs/reference/easy_text.md` | +1 | Reference page |
| `mkdocs.yml` | +2 | Nav entries |
