### PR TITLE
feat: add easy_images module for simple image processing

### DIFF
--- a/docs/reference/easy_images.md
+++ b/docs/reference/easy_images.md
@@ -1,0 +1,1 @@
+::: py_simple.easy_images

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
       - Easy Date Formatter: reference/easy_date_formatter.md
       - Easy File Manager: reference/easy_file_manager.md
       - Easy Validator: reference/easy_validator.md
+      - Easy Images: reference/easy_images.md
   - About:
       - README: readme.md
       - Contributors: about/contributors.md

--- a/py_simple_package/src/py_simple/__init__.py
+++ b/py_simple_package/src/py_simple/__init__.py
@@ -63,3 +63,6 @@ from .easy_text import (
     count_letters, count_digits, mask_part, pluralize, extract_hashtags,
     word_frequency,
 )
+from .easy_images import (
+    resize_image, convert_image, rotate_image, get_image_info,
+)

--- a/py_simple_package/src/py_simple/easy_images.py
+++ b/py_simple_package/src/py_simple/easy_images.py
@@ -1,0 +1,171 @@
+"""
+easy_images is meant to simplify common image processing tasks
+(resizing, converting, rotating, and inspecting images) using Pillow.
+"""
+
+import os
+
+from PIL import Image, UnidentifiedImageError
+
+
+class ImageProcessingError(Exception):
+    """
+    Raised when a py_simple image function fails to complete.
+
+    This covers a missing input file, an unsupported/corrupt image
+    format, or any other error that prevents a function from returning
+    a real result.
+
+    Args:
+        message (str): Description of what went wrong.
+    """
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
+def _open_image(input_path: str) -> Image.Image:
+    """Open an image file, raising ImageProcessingError with a clear
+    message instead of letting Pillow's own exceptions leak through."""
+    if not os.path.isfile(input_path):
+        raise ImageProcessingError(f"\nFile '{input_path}' not found.")
+    try:
+        return Image.open(input_path)
+    except UnidentifiedImageError as error:
+        raise ImageProcessingError(
+            f"\n'{input_path}' is not a valid or supported image file."
+        ) from error
+
+
+def resize_image(input_path: str, output_path: str, width: int, height: int):
+    """
+    Resize an image to the given dimensions and save it.
+
+    Args:
+        input_path (str): Path of the image to resize.
+        output_path (str): Path to save the resized image to.
+        width (int): Target width in pixels.
+        height (int): Target height in pixels.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import resize_image
+
+            resize_image("photo.jpg", "photo_small.jpg", 320, 240)
+            ```
+
+        === "The Traditional Way"
+            ```python
+            from PIL import Image
+
+            with Image.open("photo.jpg") as img:
+                img.resize((320, 240)).save("photo_small.jpg")
+            ```
+    """
+    with _open_image(input_path) as img:
+        img.resize((width, height)).save(output_path)
+
+
+def convert_image(input_path: str, output_path: str):
+    """
+    Convert an image to a different format based on the output file's
+    extension (e.g. PNG to JPG).
+
+    Args:
+        input_path (str): Path of the image to convert.
+        output_path (str): Path to save the converted image to. The
+            new format is inferred from this path's extension.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import convert_image
+
+            convert_image("photo.png", "photo.jpg")
+            ```
+
+        === "The Traditional Way"
+            ```python
+            from PIL import Image
+
+            with Image.open("photo.png") as img:
+                img.convert("RGB").save("photo.jpg")
+            ```
+    """
+    with _open_image(input_path) as img:
+        # JPEG has no alpha channel; converting to RGB first avoids Pillow
+        # raising on images that have one (e.g. a PNG with transparency).
+        if img.mode in ("RGBA", "P") and output_path.lower().endswith((".jpg", ".jpeg")):
+            img = img.convert("RGB")
+        img.save(output_path)
+
+
+def rotate_image(input_path: str, output_path: str, angle: float):
+    """
+    Rotate an image by the given angle (counter-clockwise) and save it.
+
+    Args:
+        input_path (str): Path of the image to rotate.
+        output_path (str): Path to save the rotated image to.
+        angle (float): Degrees to rotate counter-clockwise, e.g. 90.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import rotate_image
+
+            rotate_image("photo.jpg", "photo_rotated.jpg", 90)
+            ```
+
+        === "The Traditional Way"
+            ```python
+            from PIL import Image
+
+            with Image.open("photo.jpg") as img:
+                img.rotate(90, expand=True).save("photo_rotated.jpg")
+            ```
+    """
+    with _open_image(input_path) as img:
+        img.rotate(angle, expand=True).save(output_path)
+
+
+def get_image_info(input_path: str) -> dict:
+    """
+    Get basic information about an image.
+
+    Args:
+        input_path (str): Path of the image to inspect.
+
+    Returns:
+        dict: With keys "width", "height", "format", and "mode".
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import get_image_info
+
+            info = get_image_info("photo.jpg")
+            # {"width": 1920, "height": 1080, "format": "JPEG", "mode": "RGB"}
+            ```
+
+        === "The Traditional Way"
+            ```python
+            from PIL import Image
+
+            with Image.open("photo.jpg") as img:
+                info = {
+                    "width": img.width,
+                    "height": img.height,
+                    "format": img.format,
+                    "mode": img.mode,
+                }
+            ```
+    """
+    with _open_image(input_path) as img:
+        return {
+            "width": img.width,
+            "height": img.height,
+            "format": img.format,
+            "mode": img.mode,
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "requests>=2.25.0",
     "beautifulsoup4>=4.9.0",
     "python-benedict>=0.38.0",
+    "Pillow>=10.0.0",
 ]
 
 [project.urls]

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,0 +1,111 @@
+"""Tests for easy_images module."""
+
+import os
+import tempfile
+
+import pytest
+from PIL import Image
+
+from py_simple_package.src.py_simple.easy_images import (
+    resize_image,
+    convert_image,
+    rotate_image,
+    get_image_info,
+    ImageProcessingError,
+)
+
+
+@pytest.fixture
+def tmp_workdir():
+    """Change to a temp directory for file operations, then clean up."""
+    original_cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        yield tmpdir
+    os.chdir(original_cwd)
+
+
+@pytest.fixture
+def sample_png(tmp_workdir):
+    """A small opaque red PNG to run the functions against."""
+    path = "sample.png"
+    Image.new("RGB", (100, 60), color="red").save(path)
+    return path
+
+
+@pytest.fixture
+def sample_rgba_png(tmp_workdir):
+    """A small PNG with an alpha channel, to test JPEG conversion."""
+    path = "sample_rgba.png"
+    Image.new("RGBA", (100, 60), color=(255, 0, 0, 128)).save(path)
+    return path
+
+
+class TestResizeImage:
+    """Tests for resize_image function."""
+
+    def test_resizes_to_given_dimensions(self, sample_png):
+        resize_image(sample_png, "resized.png", 40, 20)
+        with Image.open("resized.png") as img:
+            assert img.size == (40, 20)
+
+    def test_missing_input_raises(self, tmp_workdir):
+        with pytest.raises(ImageProcessingError):
+            resize_image("does_not_exist.png", "out.png", 10, 10)
+
+
+class TestConvertImage:
+    """Tests for convert_image function."""
+
+    def test_converts_png_to_jpg(self, sample_png):
+        convert_image(sample_png, "converted.jpg")
+        with Image.open("converted.jpg") as img:
+            assert img.format == "JPEG"
+
+    def test_converts_rgba_to_jpg_without_error(self, sample_rgba_png):
+        # JPEG has no alpha channel; this must not raise.
+        convert_image(sample_rgba_png, "converted.jpg")
+        with Image.open("converted.jpg") as img:
+            assert img.format == "JPEG"
+            assert img.mode == "RGB"
+
+    def test_missing_input_raises(self, tmp_workdir):
+        with pytest.raises(ImageProcessingError):
+            convert_image("does_not_exist.png", "out.jpg")
+
+
+class TestRotateImage:
+    """Tests for rotate_image function."""
+
+    def test_rotate_90_swaps_dimensions(self, sample_png):
+        rotate_image(sample_png, "rotated.png", 90)
+        with Image.open("rotated.png") as img:
+            # A 100x60 image rotated 90 degrees becomes 60x100.
+            assert img.size == (60, 100)
+
+    def test_missing_input_raises(self, tmp_workdir):
+        with pytest.raises(ImageProcessingError):
+            rotate_image("does_not_exist.png", "out.png", 90)
+
+
+class TestGetImageInfo:
+    """Tests for get_image_info function."""
+
+    def test_returns_expected_keys(self, sample_png):
+        info = get_image_info(sample_png)
+        assert info == {
+            "width": 100,
+            "height": 60,
+            "format": "PNG",
+            "mode": "RGB",
+        }
+
+    def test_missing_input_raises(self, tmp_workdir):
+        with pytest.raises(ImageProcessingError):
+            get_image_info("does_not_exist.png")
+
+    def test_unsupported_file_raises(self, tmp_workdir):
+        with open("not_an_image.png", "w", encoding="utf-8") as f:
+            f.write("this is definitely not image data")
+        with pytest.raises(ImageProcessingError):
+            get_image_info("not_an_image.png")


### PR DESCRIPTION
## What & why

Closes #82 — adds the `easy_images` module wrapping Pillow for the common beginner tasks: resizing, converting, rotating, and inspecting images.

## Changes

- `resize_image(input_path, output_path, width, height)`
- `convert_image(input_path, output_path)` — format inferred from `output_path`'s extension; converts RGBA/P-mode images to RGB before saving as JPEG since JPEG has no alpha channel (Pillow otherwise raises).
- `rotate_image(input_path, output_path, angle)`
- `get_image_info(input_path) -> dict` — `{width, height, format, mode}`
- `ImageProcessingError` for a missing input file or an unsupported/corrupt image, matching the existing per-module exception pattern (`InvalidExtension` in `easy_file_manager`, `SomethingWentWrongError` in `easy_web`).
- Docstrings follow the existing "Py_simple vs Traditional" tabbed style.
- Registered in `__init__.py`, added `Pillow>=10.0.0` to `pyproject.toml` dependencies, added `docs/reference/easy_images.md` + `mkdocs.yml` nav entry matching the other modules.
- `tests/test_images.py` — all four functions plus missing-file/unsupported-format error paths, following the existing `tmp_workdir` fixture pattern from `test_file_manager.py`.

I kept it to the four required functions from the issue rather than also adding the "optional but nice to have" ones (filters/crop/compress), to keep this PR focused — happy to follow up with those separately if wanted.

## Testing

`pytest` — all new tests pass, and the full suite still passes (549 assertions).

One unrelated note: on Windows, tests using the `tmp_workdir` fixture throw a `PermissionError` during teardown — `os.chdir(original_cwd)` runs *after* `TemporaryDirectory`'s own cleanup, so it tries to delete a directory that's still the process's cwd. This isn't something I introduced (it reproduces identically on the existing `test_file_manager.py`, untouched by this PR), and every actual assertion still passes — just flagging it in case it's not already known, your CI presumably runs on Linux where it wouldn't surface.