### PR TITLE
Replace pygame with pygame-ce to support Python 3.14

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
 
     steps:
     - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Education",
     "Topic :: Utilities",
 ]
@@ -39,7 +41,7 @@ dependencies = [
     "python-benedict>=0.38.0",
     "Pillow>=10.0.0",
     "qrcode>=7.4.0",
-    "pygame>=2.5.0",
+    "pygame-ce>=2.5.0",
     "matplotlib>=3.0.0",
 ]
 


### PR DESCRIPTION
Closes #122

## What this changes

1. `pyproject.toml`: the dependency becomes `pygame-ce>=2.5.0`.
2. `pyproject.toml`: adds the classifiers for Python 3.13 and 3.14.
3. `tests.yml` and `pylint.yml`: adds 3.13 and 3.14 to the CI matrix.

There is no source code change. pygame-ce uses the same `pygame` import name and the same API.

## Why

Upstream pygame last released 2.6.1 on 2024-09-29. It has wheels for Python 3.10 to 3.13. It has no wheel for Python 3.14, so the package does not install there.

pygame-ce is the community fork of pygame. It released 2.5.8 on 2026-08-09. It has wheels for Python 3.10 to 3.15.

Every other dependency already works on Python 3.14.

## Test

I ran the full test suite on Python 3.14.7 with pygame-ce 2.5.8. All 774 tests pass.

pylint 4.0.7 and pytest 9.1.1 both support Python 3.14, so the new CI rows work.

## Note for users

pygame and pygame-ce install into the same `pygame` directory. A user with pygame already installed must remove it first:

```
pip uninstall pygame
pip install --upgrade py-simple-wrap
```
