### PR TITLE
test: cover is_prime even and negative branches

### DIFF
--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -173,6 +173,22 @@ def test_is_prime_zero():
     assert is_prime(0) is False
 
 
+def test_is_prime_even_composite():
+    assert is_prime(4) is False
+
+
+def test_is_prime_large_even():
+    assert is_prime(100) is False
+
+
+def test_is_prime_negative():
+    assert is_prime(-7) is False
+
+
+def test_is_prime_odd_composite_square():
+    assert is_prime(25) is False
+
+
 
 
 # percentage


### PR DESCRIPTION
Adds four `is_prime` cases to `tests/test_numbers.py`.

**Coverage: 97% → 100%** on `easy_numbers.py` (the missing line was 209).

Line 209 is the `elif is_even(number): return False` branch — the existing suite covered 0, 1, 2, 3, 9 and 17, so an even composite never reached it. `is_prime(4)` and `is_prime(100)` do.

Added two neighbours while there:

- `is_prime(-7)` — the `number > 0` guard, which returns before `limit` is computed
- `is_prime(25)` — an odd composite whose smallest factor is its own square root, the edge of the `range(3, limit, 2)` loop

All 63 tests in the file pass. Uses `pytest` and follows the existing flat `def test_*` style of the file.

Closes #142