### PR TITLE
test: cover retry with zero and single attempts

### DIFF
--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -230,3 +230,28 @@ class TestRetry:
 
         assert len(calls) == 3
         assert sleep_calls == [1, 1]
+
+    def test_zero_attempts_returns_none(self, monkeypatch):
+        """Checks the loop never runs when attempts is zero."""
+        monkeypatch.setattr(time, "sleep", lambda s: None)
+        calls = []
+
+        def never_called():
+            calls.append(1)
+            return "unreachable"
+
+        assert retry(never_called, attempts=0) is None
+        assert calls == []
+
+    def test_single_attempt_raises_without_sleeping(self, monkeypatch):
+        """Checks a lone failing attempt raises and never waits."""
+        sleep_calls = []
+        monkeypatch.setattr(time, "sleep", lambda s: sleep_calls.append(s))
+
+        def always_fails():
+            raise ValueError("nope")
+
+        with pytest.raises(ValueError):
+            retry(always_fails, attempts=1)
+
+        assert sleep_calls == []


### PR DESCRIPTION
Adds two `retry` cases to `TestRetry` in `tests/test_flow.py`.

**Coverage: 98% → 100%** on `easy_flow.py` (the missing line was 258).

Line 258 is the trailing `return None` after the loop. Every existing test passes `attempts >= 1`, so the loop always either returns a result or re-raises, and that line was unreachable. `retry(func, attempts=0)` skips the loop entirely and falls through to it — the test also asserts the callable was never invoked, so it documents the behaviour rather than just touching the line.

The second test covers `attempts=1`: the single failure re-raises immediately and `time.sleep` is never called, which pins down the `if i == attempts - 1` boundary.

Both follow the existing class style — `monkeypatch` on `time.sleep` so nothing actually waits, and a docstring per test.

All 23 tests in the file pass.

Closes #140