### PR TITLE
test: cover get_page_title, count_links and get_link_list

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3,10 +3,13 @@ import pytest
 import requests
 
 from py_simple_package.src.py_simple.easy_web import (
+    count_links,
     count_tags,
     get_all_headers,
+    get_link_list,
     get_meta_description,
     get_page_content,
+    get_page_title,
     get_tag_list,
     is_page_up,
     print_allowed_tags,
@@ -155,6 +158,41 @@ class TestEasyWeb:
         mock_get.assert_called_once_with("https://offline-site.com", timeout=10)
 
 
+class TestGetPageTitle:
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_page_title_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = (
+            b'<html><head>'
+            b'<title>Example Title</title>'
+            b'</head></html>'
+        )
+        mock_get.return_value = mock_response
+
+        result = get_page_title("https://example.com")
+        assert result == "Example Title"
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_page_title_no_title_tag(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = b'<html><body><p>No title here</p></body></html>'
+        mock_get.return_value = mock_response
+
+        with pytest.raises(SomethingWentWrongError):
+            get_page_title("https://example.com")
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_page_title_exception(self, mock_get):
+        mock_get.side_effect = requests.RequestException("Network Error")
+
+        with pytest.raises(SomethingWentWrongError):
+            get_page_title("https://invalid-url.com")
+        mock_get.assert_called_once_with("https://invalid-url.com", timeout=10)
+
+
 class TestCountTags:
 
     @patch("py_simple_package.src.py_simple.easy_web.requests.get")
@@ -212,6 +250,43 @@ class TestCountTags:
         mock_get.assert_called_once_with("https://invalid-url.com", timeout=10)
 
 
+class TestCountLinks:
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_count_links_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = (
+            b'<html><body>'
+            b'<a href="/one">One</a>'
+            b'<a href="/two">Two</a>'
+            b'<a href="/three">Three</a>'
+            b'</body></html>'
+        )
+        mock_get.return_value = mock_response
+
+        result = count_links("https://example.com")
+        assert result == 3
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_count_links_none_found(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = b'<html><body><p>No links here</p></body></html>'
+        mock_get.return_value = mock_response
+
+        result = count_links("https://example.com")
+        assert result == 0
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_count_links_exception(self, mock_get):
+        mock_get.side_effect = requests.RequestException("Network Error")
+
+        with pytest.raises(SomethingWentWrongError):
+            count_links("https://invalid-url.com")
+        mock_get.assert_called_once_with("https://invalid-url.com", timeout=10)
+
+
 class TestGetTagList:
 
     @patch("py_simple_package.src.py_simple.easy_web.requests.get")
@@ -266,6 +341,42 @@ class TestGetTagList:
 
         with pytest.raises(SomethingWentWrongError):
             get_tag_list("https://invalid-url.com", "a")
+        mock_get.assert_called_once_with("https://invalid-url.com", timeout=10)
+
+
+class TestGetLinkList:
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_link_list_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = (
+            b'<html><body>'
+            b'<a href="/one">One</a>'
+            b'<a href="/two">Two</a>'
+            b'</body></html>'
+        )
+        mock_get.return_value = mock_response
+
+        result = get_link_list("https://example.com")
+        assert result == ["/one", "/two"]
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_link_list_none_found(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = b'<html><body><p>No links here</p></body></html>'
+        mock_get.return_value = mock_response
+
+        result = get_link_list("https://example.com")
+        assert result == []
+        mock_get.assert_called_once_with("https://example.com", timeout=10)
+
+    @patch("py_simple_package.src.py_simple.easy_web.requests.get")
+    def test_get_link_list_exception(self, mock_get):
+        mock_get.side_effect = requests.RequestException("Timeout")
+
+        with pytest.raises(SomethingWentWrongError):
+            get_link_list("https://invalid-url.com")
         mock_get.assert_called_once_with("https://invalid-url.com", timeout=10)
 
 


### PR DESCRIPTION
Fixes #135. Adds unit tests for the three functions in easy_web.py that had no coverage, following the existing mock style. Verified: pytest tests/test_web.py — 33 passed.