### PR TITLE
docs: add easy_random tutorial

### DIFF
--- a/docs/tutorial/easy_random.md
+++ b/docs/tutorial/easy_random.md
@@ -1,0 +1,37 @@
+# Easy Random
+
+Choosing random values is useful for games, raffles, quizzes, and small experiments. The `easy_random` module wraps Python's `random` module with beginner-friendly helpers for common tasks.
+
+## A small real-world example
+
+Imagine you're drawing a winner from a short list of raffle entries. You can shuffle a copy of the entries and choose the first name without changing the original list.
+
+```python
+import random
+from py_simple import shuffle_list, pick_random_item
+
+random.seed(7)  # Makes this example repeatable while you learn.
+entries = ["Aiko", "Ben", "Chika"]
+shuffled_entries = shuffle_list(entries)
+winner = pick_random_item(shuffled_entries)
+
+print(shuffled_entries)
+print(winner)
+```
+
+Example output:
+
+```text
+['Chika', 'Aiko', 'Ben']
+Aiko
+```
+
+## What happened?
+
+`shuffle_list()` returned a new list with the entries in random order, leaving `entries` unchanged.
+
+`pick_random_item()` selected one item from the shuffled list. The module also includes `roll_dice()` for a random number from 1 to a chosen number of sides, `flip_coin()` for `Heads` or `Tails`, and `random_int()` for an integer between two inclusive limits.
+
+## Why use these helpers?
+
+Without these helpers, you would need to remember which `random` function fits each task and write the surrounding list-copying or validation code yourself. These small wrappers keep everyday random choices readable, while still letting Python handle the randomness.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
             - Tutorial 1: tutorial/easy_numbers.md
             - Tutorial 2: tutorial/easy_numbers2.md
         - Easy Regex: tutorial/easy_regex.md
+        - Easy Random: tutorial/easy_random.md
         - Easy Stats: tutorial/easy_stats.md
         - Easy Validator: tutorial/easy_validator.md
   - How To:


### PR DESCRIPTION
## What does this PR do?
Adds the missing `easy_random` module tutorial and links it from the MkDocs tutorial navigation.

## Why?
Resolves #168 by showing a small, repeatable raffle example and briefly explaining all module helpers.

## User impact
Readers can discover and follow an easy_random tutorial from the documentation site.

## Verification
- Ran a deterministic example using `shuffle_list` and `pick_random_item`; output matches the documented output.
- Ran `git diff --check`.
- Verified the MkDocs navigation entry and tutorial file.

## Not verified
- Full pytest/docs build was not run because the checkout environment lacks the project runtime dependency `beautifulsoup4`.