### PR TITLE
docs: add reference page for easy_config

### DIFF
--- a/docs/reference/easy_config.md
+++ b/docs/reference/easy_config.md
@@ -1,0 +1,1 @@
+::: py_simple.easy_config

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
       - Easy Archive: reference/easy_archive.md
       - Easy Async: reference/easy_async.md
       - Easy Colors: reference/easy_colors.md
+      - Easy Config: reference/easy_config.md
       - Easy Converter: reference/easy_converter.md
       - Easy CSV: reference/easy_csv.md
       - Easy Data Visualization: reference/easy_data_visualization.md


### PR DESCRIPTION
## Description

Adds the missing reference page for the `easy_config` module:

- Created `docs/reference/easy_config.md` using mkdocstrings syntax (`::: py_simple.easy_config`), following the same pattern as `easy_colors.md`
- Registered it in `mkdocs.yml` under the `Reference:` section, placed alphabetically between Easy Colors and Easy Converter

Closes #186