### PR TITLE
test: cover easy archive edge cases

### DIFF
--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -86,6 +86,11 @@ def test_zip_files_all_missing_raises(tmp_path):
         zip_files([str(tmp_path / "ghost.txt")], str(tmp_path / "out.zip"))
 
 
+def test_zip_files_empty_input_raises(tmp_path):
+    with pytest.raises(EasyArchiveError, match="No valid files to zip"):
+        zip_files([], str(tmp_path / "out.zip"))
+
+
 def test_zip_files_rejects_non_zip_extension(tmp_path):
     file1 = tmp_path / "one.txt"
     file1.write_text("1", encoding="utf-8")
@@ -104,6 +109,20 @@ def test_unzip_file_round_trip(tmp_path):
     assert result == destination
     assert (tmp_path / "restored" / "a.txt").read_text(encoding="utf-8") == "hello"
     assert (tmp_path / "restored" / "sub" / "b.txt").read_text(encoding="utf-8") == "world"
+
+
+def test_unzip_file_extracts_into_existing_destination(tmp_path):
+    project = make_folder_with_files(tmp_path)
+    zip_name = str(tmp_path / "project.zip")
+    zip_folder(str(project), zip_name)
+    destination = tmp_path / "restored"
+    destination.mkdir()
+
+    result = unzip_file(zip_name, str(destination))
+
+    assert result == str(destination)
+    assert (destination / "a.txt").read_text(encoding="utf-8") == "hello"
+    assert (destination / "sub" / "b.txt").read_text(encoding="utf-8") == "world"
 
 
 def test_unzip_file_missing_zip_raises(tmp_path):
@@ -217,6 +236,18 @@ def test_zip_folder_does_not_include_itself_when_output_is_inside_folder(tmp_pat
     assert set(names) == {"a.txt", "sub/b.txt"}
 
 
+def test_zip_folder_empty_folder_creates_empty_archive(tmp_path):
+    folder = tmp_path / "empty"
+    folder.mkdir()
+    zip_name = str(tmp_path / "empty.zip")
+
+    result = zip_folder(str(folder), zip_name)
+
+    assert result == zip_name
+    with zipfile.ZipFile(zip_name) as zf:
+        assert zf.namelist() == []
+
+
 def test_unzip_file_destination_is_existing_file_raises(tmp_path):
     file1 = tmp_path / "one.txt"
     file1.write_text("1", encoding="utf-8")
@@ -257,3 +288,23 @@ def test_zip_files_disambiguates_colliding_basenames(tmp_path, capsys):
 
     captured = capsys.readouterr()
     assert "already added from another folder" in captured.out
+
+
+def test_zip_files_numbers_collisions_with_the_same_parent_name(tmp_path):
+    files = []
+    for index in range(3):
+        folder = tmp_path / f"root{index}" / "shared"
+        folder.mkdir(parents=True)
+        path = folder / "report.txt"
+        path.write_text(str(index), encoding="utf-8")
+        files.append(str(path))
+    zip_name = str(tmp_path / "collide.zip")
+
+    zip_files(files, zip_name)
+
+    with zipfile.ZipFile(zip_name) as zf:
+        assert set(zf.namelist()) == {
+            "report.txt",
+            "report_shared.txt",
+            "report_shared_2.txt",
+        }


### PR DESCRIPTION
## What does this PR do?

Adds pytest coverage for the remaining easy_archive edge cases requested in #190: empty input, extracting into an existing directory, empty folders, and repeated basename collisions with the same parent directory name.

Fixes #190

## Type of change

- [ ] New module (`easy_*.py`)
- [ ] New function(s) in an existing module
- [ ] Bug fix
- [x] Tests
- [ ] Documentation (README, tutorial, docstrings)
- [ ] Infra / CI / tooling

## Before you submit

- [x] Tests were added or updated for what changed.
- [x] I ran the existing archive test suite locally and it passes (`28 passed`).
- [x] This passes the Simple Philosophy check: the tests document predictable beginner-facing archive behavior and prevent regressions.

## Anything else the reviewer should know?

The implementation is unchanged; this PR is intentionally limited to coverage requested by the issue.