### PR TITLE
test(easy_json): cover get_nested edge cases

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -285,3 +285,21 @@ def test_get_nested_list():
     data = {"users": [{"name": "Alice"}, {"name": "Bob"}]}
     assert get_nested(data, "users.0.name") == "Alice"
     assert get_nested(data, "users.2.name", "n/a") == "n/a"
+
+
+def test_get_nested_non_collection_returns_default():
+    assert get_nested("not-json-data", "anything", "missing") == "missing"
+
+
+def test_get_nested_rejects_invalid_list_indexes():
+    data = {"users": [{"name": "Alice"}]}
+
+    assert get_nested(data, "users.first.name", "missing") == "missing"
+    assert get_nested(data, "users.-1.name", "missing") == "missing"
+    assert get_nested(data, "users.1.name", "missing") == "missing"
+
+
+def test_get_nested_stops_when_path_continues_past_scalar():
+    data = {"user": {"name": "Alice"}}
+
+    assert get_nested(data, "user.name.first", "missing") == "missing"


### PR DESCRIPTION
## What does this PR do?

Adds regression coverage for the remaining `get_nested` branches: non-collection input, malformed and out-of-range list indexes, and paths that continue through scalar values. The focused `easy_json` suite now covers every executable line in the module.

Fixes #230

## Type of change

- [ ] New module (`easy_*.py`)
- [ ] New function(s) in an existing module
- [ ] Bug fix
- [x] Tests
- [ ] Documentation (README, tutorial, docstrings)
- [ ] Infra / CI / tooling

## Before you submit

- [x] Every new/changed public function has a docstring in the project's shape (not applicable: no public function changed).
- [x] Tests were added or updated for what changed.
- [x] I ran the existing test suite locally and it passes.
- [x] If this adds a new module: required module documentation is present (not applicable: no module added).
- [x] This passes the Simple Philosophy check by making invalid nested paths safer to understand through explicit examples.

## Anything else the reviewer should know?

- Focused baseline: 45 tests passed, 96% line coverage for `easy_json`.
- With this change: 48 focused tests passed, 100% line coverage for `easy_json`.
- Full suite: 905 tests passed.
- CI-equivalent Pylint gate: 9.10/10 with the required minimum of 8.5.
