### PR TITLE
Add a new function to easy_validator #225

### DIFF
--- a/py_simple_package/src/py_simple/__init__.py
+++ b/py_simple_package/src/py_simple/__init__.py
@@ -31,7 +31,6 @@ from .easy_validator import (
     is_valid_email, is_valid_username, is_valid_zipcode, is_valid_url,
     is_password_secure, is_valid_creditcard,is_valid_phone_number
 )
-)
 from .easy_web import (
     get_page_content, is_page_up, get_link_list, get_page_title,
     count_links, count_tags, get_tag_list, print_allowed_tags,

--- a/py_simple_package/src/py_simple/__init__.py
+++ b/py_simple_package/src/py_simple/__init__.py
@@ -112,3 +112,7 @@ from .easy_archive import (
 from .easy_config import (
     gh_workflow_config,
 )
+from .easy_validator import (
+    is_valid_email, is_valid_username, is_valid_zipcode, is_valid_url,
+    is_password_secure, is_valid_creditcard, is_valid_phone_number
+)

--- a/py_simple_package/src/py_simple/__init__.py
+++ b/py_simple_package/src/py_simple/__init__.py
@@ -29,7 +29,8 @@ from .easy_numbers import (
 )
 from .easy_validator import (
     is_valid_email, is_valid_username, is_valid_zipcode, is_valid_url,
-    is_password_secure, is_valid_creditcard
+    is_password_secure, is_valid_creditcard,is_valid_phone_number
+)
 )
 from .easy_web import (
     get_page_content, is_page_up, get_link_list, get_page_title,
@@ -111,8 +112,4 @@ from .easy_archive import (
 )
 from .easy_config import (
     gh_workflow_config,
-)
-from .easy_validator import (
-    is_valid_email, is_valid_username, is_valid_zipcode, is_valid_url,
-    is_password_secure, is_valid_creditcard, is_valid_phone_number
 )

--- a/py_simple_package/src/py_simple/easy_validator.py
+++ b/py_simple_package/src/py_simple/easy_validator.py
@@ -312,3 +312,38 @@ def is_valid_creditcard(card_num: str):
             sum += doubled if doubled < 10 else doubled - 9
 
     return sum % 10 == 0
+
+
+def is_valid_phone_number(phone_number: str) -> bool:
+    r"""
+    Returns true if the phone number is a valid US-style phone number.
+
+    Accepts an optional leading "+1" country code, an optional area code
+    in parentheses, and digit groups separated by spaces, dashes, or dots
+    (or no separator at all).
+
+    Args:
+        phone_number (str): The phone number to validate.
+
+    Returns:
+        bool: True if the phone number is valid, False otherwise.
+
+    Example:
+        === "The Py_simple Way"
+```python
+            from py_simple import is_valid_phone_number
+
+            result = is_valid_phone_number("(123) 456-7890")  # -> True
+```
+
+        === "The Traditional Way"
+```python
+            import re
+
+            pattern = r'^(\+1[\s.-]?)?(\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}$'
+            result = bool(re.fullmatch(pattern, "(123) 456-7890"))
+```
+    """
+    pattern = r'^(\+1[\s.-]?)?(\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}$'
+    return bool(re.fullmatch(pattern, phone_number))
+

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -110,3 +110,25 @@ class TestEasyValidator:
 
     def test_creditcard_validation(self, card_num, expected):
         assert is_valid_creditcard(card_num) is expected
+
+    @pytest.mark.parametrize(
+        "phone_number, expected",
+        [
+            ("1234567890", True),
+            ("123-456-7890", True),
+            ("(123) 456-7890", True),
+            ("123.456.7890", True),
+            ("123 456 7890", True),
+            ("+1 123-456-7890", True),
+            ("+11234567890", True),
+            ("12345", False),
+            ("123-456-78901", False),
+            ("abc-456-7890", False),
+            ("", False),
+            ("123-45-6789", False),
+            ("+1234567890", False),
+        ],
+    )
+
+    def test_phone_number_validation(self, phone_number, expected):
+        assert is_valid_phone_number(phone_number) is expected

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -6,7 +6,8 @@ from py_simple_package.src.py_simple.easy_validator import (
     is_valid_zipcode,
     is_valid_url,
     is_password_secure,
-    is_valid_creditcard)
+    is_valid_creditcard,
+    is_valid_phone_number)
 
 class TestEasyValidator:
 


### PR DESCRIPTION
## Summary

Adds `is_valid_phone_number()` to `easy_validator.py`

Closes #225

## What's new

- **`is_valid_phone_number(phone_number: str) -> bool`** — validates US-style phone numbers. Accepts an optional leading `+1` country code, an optional area code in parentheses, and digit groups separated by spaces, dashes, dots, or no separator at all (e.g. `1234567890`, `(123) 456-7890`, `+1 123-456-7890`).

## Files changed

- `py_simple_package/src/py_simple/easy_validator.py` — new function, added after `is_valid_creditcard`, with a docstring following the [docstring template](https://sara-czasak.github.io/py-simple-wrap/docs/contributor-hub/docstring_template/) (Args/Returns/Example with both "Py_simple Way" and "Traditional Way" tabs).
- `py_simple_package/src/py_simple/__init__.py` — added `is_valid_phone_number` to the `easy_validator` re-export block, consistent with how the other 6 validator functions are exposed.
- `tests/test_validator.py` — new parametrized test method (`test_phone_number_validation`) covering 13 cases: valid formats with/without separators and country code, plus invalid inputs (too short, too long, letters, wrong grouping, empty string).

## Testing

Ran the full validator suite locally:


Also confirmed both import styles work, per the issue's requirement:

```python
from py_simple.easy_validator import is_valid_phone_number  # required style
from py_simple import is_valid_phone_number                  # also works
```

## Checklist

- [x] Function follows the "separate, clearly named function" API style (not a generic dispatcher)
- [x] Docstring follows the docstring template, including both example tabs
- [x] Matching test added in `tests/`
- [x] Full test suite passes locally
- [x] Beginner-friendly — no new dependencies, plain `re` module like the rest of the file