### PR TITLE
feat(json): add get_json_keys helper

### DIFF
--- a/py_simple_package/src/py_simple/__init__.py
+++ b/py_simple_package/src/py_simple/__init__.py
@@ -42,7 +42,7 @@ from .easy_strings import (
 )
 from .easy_json import (
     open_json, save_json_data, pretty_json, update_json, is_json_file,
-    is_nested_json, flatten_json,
+    get_json_keys, is_nested_json, flatten_json,
 )
 from .easy_colors import (
     hex_to_rgb, rgb_to_hex, is_valid_hex, rgb_to_hsl, hsl_to_rgb,

--- a/py_simple_package/src/py_simple/easy_json.py
+++ b/py_simple_package/src/py_simple/easy_json.py
@@ -255,6 +255,55 @@ def is_json_file(filepath: str) -> bool:
         return False
 
 
+def get_json_keys(data: dict = None, filepath: str = None) -> list[str]:
+    """
+    Returns the top-level keys in a dictionary or JSON file.
+
+    Provide exactly one of ``data`` or ``filepath``. This is useful when
+    you want to quickly see what information a JSON object contains before
+    reading a specific value.
+
+    Args:
+        data (dict): A dictionary whose keys should be returned.
+        filepath (str): Path to a JSON file whose top-level keys should be
+            returned.
+
+    Returns:
+        list[str]: The dictionary's top-level keys, in their original order.
+
+    Raises:
+        EasyJsonError: If neither or both of ``data``/``filepath`` are
+            provided, or if the JSON data is not a dictionary.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple.easy_json import get_json_keys
+
+            get_json_keys(data={"name": "Sara", "active": True})
+            # -> ["name", "active"]
+            ```
+
+        === "The Traditional Way"
+            ```python
+            data = {"name": "Sara", "active": True}
+            keys = list(data.keys())
+            ```
+    """
+    if data is None and filepath is None:
+        raise EasyJsonError("\n\n\nERROR: Either data or filepath "
+                            "must be provided.") from None
+    if data is not None and filepath is not None:
+        raise EasyJsonError("\n\n\nERROR: Please provide data OR "
+                            "filepath.") from None
+
+    json_data = open_json(filepath) if filepath is not None else data
+    if not isinstance(json_data, dict):
+        raise EasyJsonError("\n\n\nERROR: JSON data must be a dictionary.")
+
+    return list(json_data.keys())
+
+
 def is_nested_json(data: dict = None, filepath: str = None) -> bool | None:
     """
     Checks whether a dictionary or JSON file contains any nested

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -4,6 +4,7 @@ import pytest
 from py_simple_package.src.py_simple.easy_json import (
     EasyJsonError,
     flatten_json,
+    get_json_keys,
     is_json_file,
     is_nested_json,
     open_json,
@@ -275,6 +276,30 @@ class TestEasyJson:
 
     def test_is_json_file_directory_is_not_a_file(self, tmp_path):
         assert is_json_file(str(tmp_path)) is False
+
+    def test_get_json_keys_with_dict(self):
+        data = {"name": "Sara", "active": True}
+
+        assert get_json_keys(data=data) == ["name", "active"]
+
+    def test_get_json_keys_with_filepath(self, tmp_path):
+        json_file = tmp_path / "sample.json"
+        json_file.write_text('{"name": "Sara", "role": "Maintainer"}',
+                             encoding="utf-8")
+
+        assert get_json_keys(filepath=str(json_file)) == ["name", "role"]
+
+    def test_get_json_keys_requires_one_input(self):
+        with pytest.raises(EasyJsonError) as exc_info:
+            get_json_keys()
+
+        assert "Either data or filepath" in str(exc_info.value)
+
+    def test_get_json_keys_rejects_non_dictionary_data(self):
+        with pytest.raises(EasyJsonError) as exc_info:
+            get_json_keys(data=["name", "role"])
+
+        assert "must be a dictionary" in str(exc_info.value)
 
 def test_get_nested_dict():
     data = {"a": {"b": {"c": 42}}}


### PR DESCRIPTION
## Summary
- add get_json_keys for listing the top-level keys of a dictionary or JSON file
- export the helper from the package API
- cover dictionary input, file input, missing input, and non-dictionary input

Closes #236

## Validation
- python -m compileall -q py_simple_package/src/py_simple/easy_json.py tests/test_json.py
- targeted smoke assertions for dictionary input and an empty dictionary

pytest is not installed in the local environment, so the full test suite could not be run locally.