### PR TITLE
Add a new function to easy_sql #222 - easy_sql function added

### DIFF
--- a/py_simple_package/src/py_simple/__init__.py
+++ b/py_simple_package/src/py_simple/__init__.py
@@ -103,7 +103,7 @@ from .easy_random import (
     roll_dice, flip_coin, pick_random_item, shuffle_list, random_int,
 )
 from .easy_sql import (
-    open_db,
+    open_db,run_update,
 )
 from .easy_archive import (
     zip_folder, zip_files, unzip_file, list_zip_contents, add_to_zip,

--- a/py_simple_package/src/py_simple/easy_sql.py
+++ b/py_simple_package/src/py_simple/easy_sql.py
@@ -450,3 +450,76 @@ def delete_all_from_table(connection: sqlite3.Connection, cursor: sqlite3.Cursor
                            f"\n\t- Uppercase letters (A-Z)"
                            f"\n\t- Lowercase letters (a-z)"
                            f"\n\t- Underscores  (_).") from None
+
+
+def run_update(connection: sqlite3.Connection, cursor: sqlite3.Cursor,
+                table_name: str, updates: dict, condition: str,
+                params: tuple = (), close_conn_after: bool = False):
+    """
+    Updates rows in a table matching a condition.
+
+    Validates `table_name` and the keys of `updates` first - only
+    letters, numbers, and underscores are allowed - to guard against
+    SQL injection before building the query string. Values in `updates`
+    and `params` are passed as parameters, not interpolated into the
+    query.
+
+    Args:
+        connection (sqlite3.Connection): Open connection to the database.
+        cursor (sqlite3.Cursor): Cursor for executing SQL statements.
+        table_name (str): Name of the table to update.
+        updates (dict): Column names mapped to their new values, e.g.
+            {"age": 30, "city": "Boston"}.
+        condition (str): SQL condition with `?` placeholders for values
+            used in the WHERE clause.
+        params (tuple): Values to substitute into the `?` placeholders
+            in `condition`, in order. Defaults to an empty tuple.
+        close_conn_after (bool): If True, closes `connection` after the
+            update runs. Defaults to False.
+
+    Raises:
+        EasySqlError: If `table_name` or any key in `updates` contains
+            anything other than letters, numbers, or underscores, or if
+            the update itself fails.
+
+    Example:
+        === "The Py_simple Way"
+```python
+            from py_simple import open_db, run_update
+
+            connection, cursor = open_db('mydb.db')
+            run_update(connection, cursor, 'users',
+                       {"age": 30, "city": "Boston"}, "name = ?", ('Ada',))
+```
+
+        === "The Traditional Way"
+```python
+            import sqlite3
+
+            conn = sqlite3.connect('test.db')
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE users SET age = ?, city = ? WHERE name = ?",
+                (30, "Boston", 'Ada'))
+            conn.commit()
+```
+    """
+    columns_str = ", ".join(updates.keys())
+    if _check_if_valid(columns_str) and _check_if_valid(table_name):
+        try:
+            set_clause = ", ".join(f"{col} = ?" for col in updates)
+            cursor.execute(
+                f"UPDATE {table_name} SET {set_clause} WHERE {condition}",
+                (*updates.values(), *params))
+            connection.commit()
+            if close_conn_after:
+                connection.close()
+        except (sqlite3.OperationalError, sqlite3.ProgrammingError,
+                sqlite3.DatabaseError) as e:
+            raise EasySqlError(f"\n\nERROR: {e}") from None
+    else:
+        raise EasySqlError(f"\n\nERROR: table_name and updates keys can "
+                           f"only contain:"
+                           f"\n\t- Uppercase letters (A-Z)"
+                           f"\n\t- Lowercase letters (a-z)"
+                           f"\n\t- Underscores  (_).") from None

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,6 +1,6 @@
 import pytest
 import sqlite3
-from py_simple.easy_sql import open_db, EasySqlError
+from py_simple.easy_sql import open_db, EasySqlError, run_update
 
 def test_open_db_success():
     """Test if the database opens successfully."""
@@ -23,3 +23,81 @@ def test_open_db_error():
     # Assert that calling the function with a bad path raises Sara's custom error
     with pytest.raises(EasySqlError):
         open_db(invalid_path)
+
+@pytest.fixture
+def users_db():
+    """Sets up an in-memory database with a small users table."""
+    conn, cursor = open_db(":memory:")
+    cursor.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)")
+    cursor.executemany(
+        "INSERT INTO users (name, age) VALUES (?, ?)",
+        [("Ada", 25), ("Grace", 40)],
+    )
+    conn.commit()
+    yield conn, cursor
+    conn.close()
+
+
+def test_run_update_changes_matching_row(users_db):
+    """Test that run_update only changes the row matching the condition."""
+    conn, cursor = users_db
+
+    run_update(conn, cursor, "users", {"age": 30}, "name = ?", ("Ada",))
+
+    cursor.execute("SELECT age FROM users WHERE name = ?", ("Ada",))
+    assert cursor.fetchone()[0] == 30
+
+    # Grace's row should be untouched
+    cursor.execute("SELECT age FROM users WHERE name = ?", ("Grace",))
+    assert cursor.fetchone()[0] == 40
+
+
+def test_run_update_multiple_columns(users_db):
+    """Test that run_update can set more than one column at once."""
+    conn, cursor = users_db
+
+    run_update(conn, cursor, "users", {"name": "Ada Lovelace", "age": 36},
+               "name = ?", ("Ada",))
+
+    cursor.execute("SELECT name, age FROM users WHERE age = 36")
+    row = cursor.fetchone()
+    assert row == ("Ada Lovelace", 36)
+
+
+def test_run_update_invalid_table_name_raises(users_db):
+    """Test that an unsafe table_name raises EasySqlError instead of running."""
+    conn, cursor = users_db
+
+    with pytest.raises(EasySqlError):
+        run_update(conn, cursor, "users; DROP TABLE users;", {"age": 99},
+                   "name = ?", ("Ada",))
+
+
+def test_run_update_invalid_column_name_raises(users_db):
+    """Test that an unsafe column name in updates raises EasySqlError."""
+    conn, cursor = users_db
+
+    with pytest.raises(EasySqlError):
+        run_update(conn, cursor, "users", {"age; DROP TABLE users;": 99},
+                   "name = ?", ("Ada",))
+
+
+def test_run_update_bad_condition_raises(users_db):
+    """Test that a condition referencing a non-existent column surfaces as EasySqlError."""
+    conn, cursor = users_db
+
+    with pytest.raises(EasySqlError):
+        run_update(conn, cursor, "users", {"age": 99},
+                   "not_a_real_column = ?", ("Ada",))
+
+
+def test_run_update_closes_connection_when_requested(users_db):
+    """Test that close_conn_after=True closes the connection after updating."""
+    conn, cursor = users_db
+
+    run_update(conn, cursor, "users", {"age": 50}, "name = ?", ("Ada",),
+               close_conn_after=True)
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn.execute("SELECT 1")


### PR DESCRIPTION

For issue #222 

Added **run_update** function - Updates rows in a table matching a condition.

All 8 tests pass (2 pre-existing + 6 new). Full suite (936 tests) passes with no regressions.

Also confirmed both import styles work, per the issue's requirement:

```python
from py_simple.easy_sql import run_update  # required style
from py_simple import run_update            # also works
```

## Checklist

- [x] Function follows the "separate, clearly named function" API style (not a generic dispatcher)
- [x] Docstring follows the docstring template, including both example tabs
- [x] Matching tests added in `tests/` — including injection-guard and error-path cases, matching the safety bar the rest of the module holds itself to
- [x] Full test suite passes locally
- [x] Beginner-friendly — no new dependencies, same validation pattern as the existing write functions