### PR TITLE
feat(easy_ai): add translate_text() function

### DIFF
--- a/py_simple_package/src/py_simple/easy_ai.py
+++ b/py_simple_package/src/py_simple/easy_ai.py
@@ -284,6 +284,52 @@ def summarize_text(ai_model: BaseChatModel, text: str) -> str:
         raise EasyAIError(f"\n\n\nERROR: {e}") from None
 
 
+def translate_text(ai_model: BaseChatModel, text: str, target_lang: str = "English") -> str:
+    """
+    Sends a request to translate the provided text into the target
+    language using the given LangChain chat model, without you having
+    to format messages manually.
+
+    Args:
+        ai_model (BaseChatModel): A LangChain chat model instance,
+            such as one returned by `get_model()`.
+        text (str): The raw text string to be translated.
+        target_lang (str): The name of the language to translate
+            into (e.g. "French", "Spanish", "German").
+            Defaults to "English".
+
+    Returns:
+        str: The translated text.
+
+    Raises:
+        EasyAIError: If the underlying model call fails.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import get_model, translate_text
+
+            model = get_model("anthropic", "claude-sonnet-4-6")
+            translation = translate_text(model, "Hola mundo", target_lang="English")
+            ```
+
+        === "The Traditional Way"
+            ```python
+            from langchain_anthropic import ChatAnthropic
+            from langchain_core.messages import HumanMessage
+
+            model = ChatAnthropic(model_name="claude-sonnet-4-6")
+            translation = model.invoke([
+                HumanMessage(content="Translate to English: Hola mundo")
+            ]).content
+            ```
+    """
+    try:
+        prompt = f"Translate to {target_lang}:\n\n{text}"
+        return ask_ai(ai_model, prompt)
+    except Exception as e:
+        raise EasyAIError(f"\n\n\nERROR: {e}") from None
+
 # ⚠️️ WORK IN PROGRESS ⚠️
 # This class will eventually take the complexity of setting up an agent
 # with LangChain and turning it into something simple.

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 from py_simple.easy_ai import (
     summarize_text, 
+    translate_text,
     get_model,
     ask_ai,
     ai_chat,
@@ -117,3 +118,41 @@ def test_ai_chat_sends_message_then_exits(capsys):
     captured = capsys.readouterr()
     assert "AI: Hi!" in captured.out
     mock_model.invoke.assert_called_once()
+
+def test_translate_text_success():
+    """Test that translate_text correctly returns model response content."""
+    mock_model = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = "Hello world"
+    mock_model.invoke.return_value = mock_response
+
+    result = translate_text(mock_model, "Hola mundo", target_lang="English")
+
+    assert result == "Hello world"
+    mock_model.invoke.assert_called_once()
+
+
+def test_translate_text_default_target_lang():
+    """Test that translate_text defaults to English when target_lang not specified."""
+    mock_model = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = "Good morning"
+    mock_model.invoke.return_value = mock_response
+
+    result = translate_text(mock_model, "Buenos días")
+
+    assert result == "Good morning"
+    # verify the prompt included "English"
+    call_args = mock_model.invoke.call_args[0][0]
+    assert "English" in call_args
+
+
+def test_translate_text_error():
+    """Test that translate_text wraps execution errors in EasyAIError."""
+    mock_model = MagicMock()
+    mock_model.invoke.side_effect = Exception("Model timeout")
+
+    with pytest.raises(EasyAIError) as exc_info:
+        translate_text(mock_model, "Bonjour")
+
+    assert "Model timeout" in str(exc_info.value)


### PR DESCRIPTION
## Summary
Adds `translate_text()` — a new function in `easy_ai` that sends text to an LLM for translation into a specified target language, complementing the existing `summarize_text()`.

## Changes
- **`easy_ai.py`**: Added `translate_text(ai_model, text, target_lang='English')` with full Google-style docstring, example blocks, and error wrapping.
- **`test_ai.py`**: Added 3 unit tests: success path, default-language behaviour, error wrapping.

## Motivation
The `easy_ai` module had summarisation but no translation. Translation is a natural pairing and frequently requested for beginner-friendly LLM wrappers.

Fixes #243