### PR TITLE
feat: add hex color extraction helper

### DIFF
--- a/py_simple_package/src/py_simple/__init__.py
+++ b/py_simple_package/src/py_simple/__init__.py
@@ -53,7 +53,7 @@ from .easy_flow import (
 )
 from .easy_regex import (
     extract_urls, extract_numbers, extract_number_sequences,
-    extract_emails,
+    extract_emails, extract_hex_colors,
 )
 from .easy_async import (
     run_at_the_same_time_no_params, run_at_the_same_time_with_params,

--- a/py_simple_package/src/py_simple/easy_regex.py
+++ b/py_simple_package/src/py_simple/easy_regex.py
@@ -138,3 +138,44 @@ def extract_numbers(text: str) -> list | None:
     """
     pattern = r'[0-9]+'
     return re.findall(pattern, text)
+
+
+def extract_hex_colors(text: str) -> list | None:
+    r"""
+    Returns a list of CSS-style hexadecimal color codes found in the text.
+
+    Supports the 3, 4, 6, and 8 digit forms, including their leading `#`.
+
+    Arguments:
+        text (str): Text to search for hexadecimal color codes.
+
+    Returns:
+        list: All hexadecimal color codes found in the text. Empty list if
+            none are found.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import extract_hex_colors
+
+            result = extract_hex_colors("Use #fff on #1a2b3c")
+            # -> ['#fff', '#1a2b3c']
+            ```
+
+        === "The Traditional Way"
+            ```python
+            import re
+
+            pattern = (
+                r'(?<![\\w#])#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|'
+                r'[0-9a-fA-F]{4}|[0-9a-fA-F]{3})\\b'
+            )
+            result = re.findall(pattern, "Use #fff on #1a2b3c")
+            # -> ['#fff', '#1a2b3c']
+            ```
+    """
+    pattern = (
+        r'(?<![\w#])#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|'
+        r'[0-9a-fA-F]{4}|[0-9a-fA-F]{3})\b'
+    )
+    return re.findall(pattern, text)

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -2,10 +2,13 @@ from py_simple_package.src.py_simple.easy_regex import (
     extract_emails,
     extract_urls,
     extract_number_sequences,
-    extract_numbers
+    extract_numbers,
+    extract_hex_colors,
 )
 
 import pytest
+
+from py_simple_package.src.py_simple import extract_hex_colors as public_extract_hex_colors
 
 # email test
 @pytest.mark.parametrize(
@@ -64,3 +67,21 @@ def test_is_number_sequence_extracted(input_text, expected):
 
 def test_is_number_extracted(input_text,expected):
     assert extract_numbers(input_text) == expected
+
+
+@pytest.mark.parametrize(
+    "input_text, expected",
+    [
+        ("Use #fff on #1a2b3c", ["#fff", "#1a2b3c"]),
+        ("Alpha colors: #abcd and #12345678", ["#abcd", "#12345678"]),
+        ("Case is preserved: #Aa00Ff", ["#Aa00Ff"]),
+        ("Ignore #12, #12345, #ggg, and abc#fff", []),
+        ("No colors here", []),
+    ],
+)
+def test_hex_colors_are_extracted(input_text, expected):
+    assert extract_hex_colors(input_text) == expected
+
+
+def test_extract_hex_colors_is_available_from_public_api():
+    assert public_extract_hex_colors is extract_hex_colors


### PR DESCRIPTION
Closes #221.

Adds `extract_hex_colors()` for CSS-style 3, 4, 6, and 8 digit colors, exposes it from `py_simple`, and covers valid and malformed input.

Validation: 21 focused tests pass; Pylint 9.27/10. The full suite has 1,058 passes and 3 unrelated existing `easy_ai.translate_text` failures.
