### PR TITLE
test: import public random helper

### DIFF
--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,4 +1,6 @@
 import pytest
+from py_simple_package.src.py_simple import pick_random_items as public_pick_random_items
+
 from py_simple_package.src.py_simple.easy_random import (
     roll_dice,
     flip_coin,


### PR DESCRIPTION
The public API assertion added in #261 missed its alias import, causing the full test suite to fail with `NameError`. This restores the import and the full suite now passes (1072 tests).
