### PR TITLE
feat: add thumbnail helper

### DIFF
--- a/py_simple_package/src/py_simple/__init__.py
+++ b/py_simple_package/src/py_simple/__init__.py
@@ -81,7 +81,7 @@ from .easy_stats import (
     median, mode, data_range, variance, standard_deviation, percentile, z_score, interquartile_range
 )
 from .easy_images import (
-    resize_image, convert_image, rotate_image, get_image_info,
+    resize_image, create_thumbnail, convert_image, rotate_image, get_image_info,
 )
 from .easy_game import (
     basic_game_setup, check_if_quit, get_mouse_position,

--- a/py_simple_package/src/py_simple/easy_images.py
+++ b/py_simple_package/src/py_simple/easy_images.py
@@ -67,6 +67,52 @@ def resize_image(input_path: str, output_path: str, width: int, height: int):
         img.resize((width, height)).save(output_path)
 
 
+def create_thumbnail(
+    input_path: str, output_path: str, max_width: int, max_height: int
+):
+    """
+    Create a thumbnail that fits within the given dimensions.
+
+    The image keeps its original aspect ratio and is never enlarged.
+
+    Args:
+        input_path (str): Path of the source image.
+        output_path (str): Path to save the thumbnail to.
+        max_width (int): Maximum thumbnail width in pixels.
+        max_height (int): Maximum thumbnail height in pixels.
+
+    Raises:
+        ValueError: If either maximum dimension is not a positive integer.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import create_thumbnail
+
+            create_thumbnail("photo.jpg", "thumbnail.jpg", 320, 320)
+            ```
+
+        === "The Traditional Way"
+            ```python
+            from PIL import Image
+
+            with Image.open("photo.jpg") as img:
+                img.thumbnail((320, 320))
+                img.save("thumbnail.jpg")
+            ```
+    """
+    dimensions = (max_width, max_height)
+    if any(
+        not isinstance(value, int) or isinstance(value, bool) or value < 1
+        for value in dimensions
+    ):
+        raise ValueError("Maximum width and height must be positive integers.")
+
+    with _open_image(input_path) as img:
+        img.thumbnail((max_width, max_height))
+        img.save(output_path)
+
+
 def convert_image(input_path: str, output_path: str):
     """
     Convert an image to a different format based on the output file's

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -5,8 +5,10 @@ import tempfile
 
 import pytest
 from PIL import Image
+from py_simple_package.src.py_simple import create_thumbnail as public_create_thumbnail
 
 from py_simple_package.src.py_simple.easy_images import (
+    create_thumbnail,
     resize_image,
     convert_image,
     rotate_image,
@@ -54,6 +56,39 @@ class TestResizeImage:
     def test_missing_input_raises(self, tmp_workdir):
         with pytest.raises(ImageProcessingError):
             resize_image("does_not_exist.png", "out.png", 10, 10)
+
+
+class TestCreateThumbnail:
+    """Tests for create_thumbnail function."""
+
+    def test_fits_within_dimensions_and_preserves_aspect_ratio(self, sample_png):
+        create_thumbnail(sample_png, "thumbnail.png", 40, 40)
+        with Image.open("thumbnail.png") as img:
+            assert img.size == (40, 24)
+
+    def test_does_not_enlarge_small_image(self, sample_png):
+        create_thumbnail(sample_png, "thumbnail.png", 200, 200)
+        with Image.open("thumbnail.png") as img:
+            assert img.size == (100, 60)
+
+    @pytest.mark.parametrize(
+        "max_width, max_height",
+        [(0, 20), (20, -1), (20.5, 20), (True, 20)],
+    )
+    def test_rejects_invalid_dimensions(
+        self, sample_png, max_width, max_height
+    ):
+        with pytest.raises(ValueError):
+            create_thumbnail(
+                sample_png, "thumbnail.png", max_width, max_height
+            )
+
+    def test_missing_input_raises(self, tmp_workdir):
+        with pytest.raises(ImageProcessingError):
+            create_thumbnail("does_not_exist.png", "out.png", 20, 20)
+
+    def test_is_available_from_public_api(self):
+        assert public_create_thumbnail is create_thumbnail
 
 
 class TestConvertImage:


### PR DESCRIPTION
Adds `create_thumbnail()` with aspect-ratio preservation, no upscaling, dimension validation, public export, examples, and tests.

Fixes #217

Tests: 18 image tests and 1,079 unaffected suite tests pass. The one deselected upstream test is repaired in #263. Pylint: 10/10 for `easy_images.py`.
