### PR TITLE
Added a function for generating a slug from a string.

### DIFF
--- a/docs/tutorial/easy_generator.md
+++ b/docs/tutorial/easy_generator.md
@@ -30,6 +30,8 @@ J4Yx8Qv3...
 
 `generate_password()` creates a randomized password containing lowercase letters, uppercase letters, digits, and special characters according to the options you provide.
 
+`generate_slug()` converts a valid string to a URL-friendly string. 
+
 `generate_uuid()` generates a random UUID version 4, which is useful when you need a unique identifier.
 
 `generate_api_key()` generates a secure, URL-safe random string using Python's `secrets` module, making it suitable for API keys and access tokens.

--- a/py_simple_package/src/py_simple/__init__.py
+++ b/py_simple_package/src/py_simple/__init__.py
@@ -90,7 +90,7 @@ from .easy_game import (
 )
 from .easy_generator import (
     generate_qr_code, generate_password, generate_otp, generate_api_key,
-    generate_uuid,
+    generate_uuid, generate_slug,
 )
 from .easy_math import (
     get_least_common_multiple, factorial, fibonacci, prime_factorization,

--- a/py_simple_package/src/py_simple/easy_generator.py
+++ b/py_simple_package/src/py_simple/easy_generator.py
@@ -2,6 +2,8 @@
 easy_generator helps generate things faster.
 """
 
+import re
+import unicodedata
 import string
 import random
 import qrcode
@@ -109,6 +111,53 @@ def generate_password(pass_length: int = 12, uppercase_chars: int = 2,
             all_clear = True
 
     return ''.join(pass_chars)
+
+
+def generate_slug(text: str) -> str:
+    """
+    Generates a slug(URL-friendly string) from string. 
+
+    Args:
+        text (str): The text to be converted to a slug.
+
+    Returns:
+        str: A URL-friendly slug.
+
+    Raises:
+        EasyGeneratorError: If `str` is empty, or if the 
+        slug conversion fails.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            from py_simple import generate_slug
+            
+            text = "Hello This-Becomes_A slug"
+            slug = generate_slug(text)
+            print(slug)  # 'hello-this-becomes-a-slug'
+            ```
+
+        === "The Traditional Way"
+            ```python
+            import re
+            import unicodedata
+
+            text = "Hello This-Becomes_A slug"
+
+            normalized = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+            lowercased = normalized.lower()
+            slug = re.sub(r"[^a-z0-9]+", "-", lowercased).strip("-")
+            print(slug)
+    """
+    if not isinstance(text, str):
+        raise EasyGeneratorError("You need to provide a string.")
+    # Unicode Normalization Form KD (NFKD) is the most aggressive normalization form
+    normalized_text = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+    lowercased_text = normalized_text.lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", lowercased_text).strip("-")
+    if not slug:
+        raise EasyGeneratorError("This string has no valid characters to convert.")
+    return slug
 
 
 def generate_qr_code(data_to_encode: str) -> None:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -10,6 +10,7 @@ from py_simple_package.src.py_simple.easy_generator import (
     generate_password,
     generate_qr_code,
     generate_uuid,
+    generate_slug,
 )
 
 
@@ -81,6 +82,37 @@ def test_generate_password_no_adjacent_duplicates(length):
         for first, second in zip(password, password[1:])
     )
 
+
+@pytest.mark.parametrize(
+    "text, expected_slug",
+    [
+        ("Hello World", "hello-world"),
+        ("Fiancé", "fiance"),
+        ("What_a!string  name ", "what-a-string-name"),
+        ("   spaces at start", "spaces-at-start"),
+        ("test-slug", "test-slug"),
+    ],
+)
+def test_generate_slug_passing(text, expected_slug):
+    actual_slug = generate_slug(text)
+
+    assert actual_slug == expected_slug
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "  ",
+        "!!!",
+        None,
+        456,
+        -421.99,
+    ],
+)
+def test_generate_slug_rejects_invalid_string(text):
+    with pytest.raises(EasyGeneratorError):
+        generate_slug(text)
 
 @pytest.mark.parametrize(
     "data",


### PR DESCRIPTION


## Test coverage 
We have added two different tests to cover passing and failing string, a total of 9 after we parameterize. 


## What does this PR do?

This function can convert a normal string to a slug, and will fail on invalid strings with a user directed 
error message. 
Fixes #216 

## Type of change
A singular new function in an existing module
Tests
Documentation 

## Before you submit

This is all passing and correct. pytest succeeds on the module as expected.

- [x] Every new/changed public function has a docstring in the
      [project's shape](https://sara-czasak.github.io/py-simple-wrap/docs/contributor-hub/docstring_template/) —
      Args/Returns (if applicable) + an Example block with both the
      "Py_simple Way" and "Traditional Way" tabs.
- [x] Tests were added or updated for what changed.
- [x] I ran the existing test suite locally and it passes.
- [x] If this adds a new module: it has a module-level docstring
      (`"""easy_<name> is meant to simplify ..."""`), a tutorial page in
      `docs/tutorial/`, and an entry in `mkdocs.yml`'s nav.
- [x] This passes the [Simple Philosophy](../CONTRIBUTING.md#the-simple-philosophy)
      check: *does this make a complex task easier for a beginner?*

## Anything else the reviewer should know?

I would love to help contribute further to this project, looks like fun.
I have also notices several bugs in that module which warrant a small rewrite. 
