### PR TITLE
feat: add to_title_case to easy_strings

### DIFF
--- a/py_simple_package/src/py_simple/easy_strings.py
+++ b/py_simple_package/src/py_simple/easy_strings.py
@@ -93,6 +93,48 @@ def to_kebab_case(text: str) -> str:
     return cleaned_text.lower().replace(" ", "-")
 
 
+def to_title_case(text: str) -> str:
+    """
+    Converts text to Title Case, where the first letter of each word
+    is capitalized and the rest are lowercased. Preserves apostrophes so
+    contractions like "don't" stay intact.
+
+    Args:
+        text (str): Text to convert.
+
+    Returns:
+        str: Text converted to Title Case.
+
+    Example:
+        === "The Py_simple Way"
+```python
+            from py_simple import to_title_case
+            result = to_title_case("hello world")  # -> "Hello World"
+```
+        === "The Traditional Way"
+```python
+            text = "hello world"
+            result = " ".join(word.capitalize() for word in text.split())
+```
+    """
+    # Same normalization pipeline as _separate_words, but preserve
+    # apostrophes so contractions like "don't" survive.
+    text = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", text)
+    text = re.sub(r"[_\-]+", " ", text)
+    text = re.sub(r"[^\w\s']", " ", text)
+    text = remove_extra_spaces(text)
+
+    result_words = []
+    for word in text.split():
+        capitalized_word = word
+        for i, character in enumerate(word):
+            if character.isalpha():
+                capitalized_word = word[:i] + character.upper() + word[i + 1:].lower()
+                break
+        result_words.append(capitalized_word)
+    return " ".join(result_words)
+
+
 def is_palindrome(text: str) -> bool:
     """
     Returns True when text reads the same forwards and backwards.
@@ -200,3 +242,11 @@ def _separate_words(text: str) -> str:
     text = re.sub(r"[_\-]+", " ", text)
     text = re.sub(r"[^\w\s]", " ", text)
     return remove_extra_spaces(text)
+
+
+def _capitalize_word(word: str) -> str:
+    """Uppercases the first alphabetic character, lowercases the rest."""
+    for i, character in enumerate(word):
+        if character.isalpha():
+            return word[:i] + character.upper() + word[i + 1:].lower()
+    return word

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -7,6 +7,7 @@ from py_simple_package.src.py_simple.easy_strings import (
     remove_extra_spaces,
     to_kebab_case,
     to_snake_case,
+    to_title_case,
 )
 
 
@@ -100,3 +101,24 @@ def test_is_alphanumeric(text, expected):
 )
 def test_count_words(text, expected):
     assert count_words(text) == expected
+    
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("hello world", "Hello World"),
+        ("HELLO WORLD", "Hello World"),
+        ("hello_world", "Hello World"),
+        ("hello-world", "Hello World"),
+        ("helloWorldFromPython", "Hello World From Python"),
+        ("don't stop", "Don't Stop"),
+        ("y'all can't", "Y'all Can't"),
+        ("'quoted text'", "'Quoted Text'"),
+        ("Python 3 Basics", "Python 3 Basics"),
+        ("  multiple   spaces  ", "Multiple Spaces"),
+        ("", ""),
+        ("   ", ""),
+    ],
+)
+def test_to_title_case(text, expected):
+    assert to_title_case(text) == expected


### PR DESCRIPTION
Refs #224

Adds `to_title_case(text)` to `easy_strings`, filling the gap between `to_snake_case` and `to_kebab_case`.

## What it does

Converts text to Title Case with the first alphabetic character of each word uppercased and the rest lowercased. Handles the same input formats as its sibling functions (snake_case, kebab-case, camelCase, mixed spacing).

## Design notes

- Went with inline regex rather than modifying `_separate_words`, kept the helper untouched so `to_snake_case`, `to_kebab_case`, and `count_words` behave identically to before. Small duplication (3 lines) in exchange for zero risk to existing functions.
- Preserves apostrophes so contractions like `"don't stop"` become `"Don't Stop"` instead of `"Don T Stop"`.
- Uses a "find first alphabetic character" loop instead of `str.capitalize()` so leading punctuation (`"'quoted'"` → `"'Quoted'"`) works correctly.

## Tests

12 cases in `test_to_title_case` covering:
- Basic input, all-caps input
- snake_case, kebab-case, camelCase normalization
- Contractions and multiple contractions
- Leading apostrophes and quoted text
- Numbers, whitespace normalization, empty string, whitespace-only

All pass locally.