### PR TITLE
feat: add easy_logging for code blocks, functions, and methods

### DIFF
--- a/docs/reference/easy_logging.md
+++ b/docs/reference/easy_logging.md
@@ -1,0 +1,1 @@
+::: py_simple.easy_logging

--- a/docs/tutorial/easy_logging.md
+++ b/docs/tutorial/easy_logging.md
@@ -1,0 +1,52 @@
+# Easy Logging
+
+Recording when an operation starts, finishes, or fails often means repeating the same logging calls. The `easy_logging` module wraps Python's standard `logging` module with helpers for code blocks, functions, and methods.
+
+## A small real-world example
+
+Imagine you're preparing an order summary and want to see which customer's total is being calculated.
+
+```python
+import logging
+from py_simple import log_function, log_step
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+@log_function("Calculate total for {customer}")
+def calculate_total(customer: str, prices: list[float], discount: float = 0) -> float:
+    return sum(prices) - discount
+
+
+with log_step("Prepare order summary"):
+    total = calculate_total("Ada", [20, 30], discount=5)
+```
+
+Example output:
+
+```text
+INFO: Starting: Prepare order summary
+INFO: Starting: Calculate total for Ada
+INFO: Finished: Calculate total for Ada
+INFO: Finished: Prepare order summary
+```
+
+## What happened?
+
+`logging.basicConfig()` enables INFO messages and sets their format. Configure logging once when your application starts; these helpers use the root logger and its existing configuration.
+
+`log_step()` logs entry into the `with` block and its successful completion.
+
+`log_function()` logs the function call and replaces `{customer}` with `"Ada"`. Templates can use positional arguments, keyword arguments, and default values for omitted arguments. The function still returns its normal result, so `total` is `45`. The decorator also works on synchronous methods; `self` and `cls` are excluded from template fields.
+
+If a block or decorated function raises an exception, the helper logs an ERROR message with the traceback and re-raises the original exception. It does not log a successful completion for that operation.
+
+## Why use these helpers?
+
+These helpers handle the repeated start, success, and failure logging around an operation, keeping the code focused on its task. Use `log_step()` for a selected block and `log_function()` when every call to a synchronous function or method should be logged.
+
+See the [Easy Logging reference](../reference/easy_logging.md) for argument details and examples alongside their standard-library equivalents.
+
+## Further reading
+
+For the reasoning behind these helpers and a walkthrough of using context managers and decorators for logging, read [How to Add Logging Without Cluttering Your Code](https://spaceshaman.github.io/posts/how-to-add-logging-without-cluttering-your-code/) by SpaceShaman.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
             - Tutorial 1: tutorial/easy_json.md
             - Tutorial 2: tutorial/easy_json2.md
         - Easy Lists: tutorial/easy_lists.md
+        - Easy Logging: tutorial/easy_logging.md
         - Easy Math:
             - Tutorial 1: tutorial/easy_math.md
             - Tutorial 2: tutorial/easy_math2.md
@@ -94,6 +95,7 @@ nav:
       - Easy Images: reference/easy_images.md
       - Easy Json: reference/easy_json.md
       - Easy Lists: reference/easy_lists.md
+      - Easy Logging: reference/easy_logging.md
       - Easy Math: reference/easy_math.md
       - Easy Numbers: reference/easy_numbers.md
       - Easy Random: reference/easy_random.md

--- a/py_simple_package/src/py_simple/__init__.py
+++ b/py_simple_package/src/py_simple/__init__.py
@@ -123,3 +123,6 @@ from .easy_config import (
 from .easy_ai import (
     ask_ai, summarize_text, translate_text, get_model,
 )
+from .easy_logging import (
+    log_step, log_function
+)

--- a/py_simple_package/src/py_simple/easy_logging.py
+++ b/py_simple_package/src/py_simple/easy_logging.py
@@ -1,0 +1,177 @@
+"""
+easy_logging is meant to simplify logging code blocks and function calls.
+Built on top of the logging module, it handles start, success, and error
+messages without repeating try/except blocks.
+
+Configure logging in your application before using these helpers, for
+example with logging.basicConfig(level=logging.INFO).
+"""
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from functools import wraps
+from inspect import signature
+from typing import Callable, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+@contextmanager
+def log_step(message: str) -> Iterator[None]:
+    """
+    Logs the start, successful completion, or failure of a code block.
+
+    Writes "Starting:" and "Finished:" messages at INFO level. If the
+    block raises an Exception, logs "Error during:" at ERROR level with
+    the traceback and re-raises the original exception instead of logging
+    a successful completion. Uses the root logger and its configuration.
+
+    Args:
+        message (str): Description of the operation, such as
+            "Calculate total".
+
+    Yields:
+        None: Runs the enclosed code block without providing an object
+            for an optional `as` target.
+
+    Raises:
+        Exception: Re-raises any Exception raised by the enclosed block
+            after logging it.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            import logging
+            from py_simple.easy_logging import log_step
+
+            logging.basicConfig(level=logging.INFO)
+
+            with log_step("Calculate total"):
+                total = sum([10, 20, 30])
+
+            print(total)  # -> 60
+            ```
+
+        === "The Traditional Way"
+            ```python
+            import logging
+
+            logging.basicConfig(level=logging.INFO)
+
+            try:
+                logging.info("Starting: Calculate total")
+                total = sum([10, 20, 30])
+            except Exception:
+                logging.exception("Error during: Calculate total")
+                raise
+            else:
+                logging.info("Finished: Calculate total")
+
+            print(total)  # -> 60
+            ```
+    """
+    try:
+        logging.info(f"Starting: {message}")
+        yield
+    except Exception:
+        logging.exception(f"Error during: {message}")
+        raise
+    else:
+        logging.info(f"Finished: {message}")
+
+
+def log_function(
+    message_template: str,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """
+    Creates a decorator that logs each call to a synchronous function and method.
+
+    Formats the message using the function's argument names and values,
+    including default values for omitted arguments. Excludes `self` and
+    `cls` from the formatting context. Uses log_step to log the start,
+    successful completion, or exception with a traceback through the
+    root logger. Preserves the function's metadata and return value.
+
+    Argument binding and message formatting happen before logging starts;
+    errors in those steps propagate without being logged by this helper.
+    For async functions or generators, this decorator only logs creation
+    of the coroutine or generator, not its later execution.
+
+    Args:
+        message_template (str): Message with named str.format_map fields
+            matching function parameters, such as "Add {a} and {b}".
+            Format specifications such as "{price:.2f}" are supported.
+
+    Returns:
+        Callable[[Callable[P, R]], Callable[P, R]]: Decorator that wraps a
+            function with logging while preserving its parameters and
+            return type.
+
+    Raises:
+        KeyError: A message field is missing from the formatting context.
+        ValueError: The message template or a format specification is
+            invalid.
+        TypeError: The supplied arguments cannot be bound to the wrapped
+            function's signature.
+        Exception: Re-raises any Exception from the wrapped function
+            after logging it.
+
+    Example:
+        === "The Py_simple Way"
+            ```python
+            import logging
+            from py_simple.easy_logging import log_function
+
+            logging.basicConfig(level=logging.INFO)
+
+            @log_function("Add {a} and {b}")
+            def add(a: int, b: int = 10) -> int:
+                return a + b
+
+            print(add(5))  # -> 15; logs "Add 5 and 10"
+            ```
+
+        === "The Traditional Way"
+            ```python
+            import logging
+
+            logging.basicConfig(level=logging.INFO)
+
+            def add(a: int, b: int = 10) -> int:
+                message = f"Add {a} and {b}"
+                try:
+                    logging.info(f"Starting: {message}")
+                    result = a + b
+                except Exception:
+                    logging.exception(f"Error during: {message}")
+                    raise
+                else:
+                    logging.info(f"Finished: {message}")
+                    return result
+
+            print(add(5))  # -> 15; logs "Add 5 and 10"
+            ```
+    """
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        func_signature = signature(func)
+
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            bound_args = func_signature.bind(*args, **kwargs)
+            bound_args.apply_defaults()
+            log_context = {
+                name: value
+                for name, value in bound_args.arguments.items()
+                if name not in {"self", "cls"}
+            }
+            message = message_template.format_map(log_context)
+
+            with log_step(message):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,105 @@
+"""Tests for easy_logging module."""
+
+import logging
+
+import pytest
+
+from py_simple_package.src.py_simple.easy_logging import log_function, log_step
+
+
+def test_log_step_logs_start_and_finish(caplog):
+    with caplog.at_level(logging.INFO):
+        with log_step("Calculate total"):
+            assert caplog.messages == ["Starting: Calculate total"]
+            total = sum([10, 20, 30])
+
+    assert total == 60
+    assert [(record.levelno, record.message) for record in caplog.records] == [
+        (logging.INFO, "Starting: Calculate total"),
+        (logging.INFO, "Finished: Calculate total"),
+    ]
+
+
+def test_log_step_logs_error_and_reraises(caplog):
+    error = ValueError("Operation failed")
+
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(ValueError) as exc_info:
+            with log_step("Calculate total"):
+                raise error
+
+    assert exc_info.value is error
+    assert caplog.messages == [
+        "Starting: Calculate total",
+        "Error during: Calculate total",
+    ]
+    record = caplog.records[-1]
+    assert record.levelno == logging.ERROR
+    assert record.exc_info[1] is error
+    assert record.exc_info[2] is not None
+
+
+@pytest.mark.parametrize(
+    "args, kwargs, expected, message",
+    [
+        ((2, 3), {}, 5, "Add 2 and 3"),
+        ((2,), {"b": 4}, 6, "Add 2 and 4"),
+        ((2,), {}, 12, "Add 2 and 10"),
+    ],
+)
+def test_log_function_formats_arguments_and_returns_result(
+    caplog, args, kwargs, expected, message
+):
+    @log_function("Add {a} and {b}")
+    def add(a, b=10):
+        return a + b
+
+    with caplog.at_level(logging.INFO):
+        result = add(*args, **kwargs)
+
+    assert result == expected
+    assert caplog.messages == [f"Starting: {message}", f"Finished: {message}"]
+
+
+def test_log_function_logs_error_and_reraises(caplog):
+    error = ValueError("Invalid value")
+
+    @log_function("Process {value}")
+    def process(value):
+        raise error
+
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(ValueError) as exc_info:
+            process(5)
+
+    assert exc_info.value is error
+    assert caplog.messages == ["Starting: Process 5", "Error during: Process 5"]
+    record = caplog.records[-1]
+    assert record.levelno == logging.ERROR
+    assert record.exc_info[1] is error
+    assert record.exc_info[2] is not None
+
+
+def test_log_function_preserves_metadata():
+    @log_function("Add {a} and {b}")
+    def add(a, b):
+        """Returns the sum of two numbers."""
+        return a + b
+
+    assert add.__name__ == "add"
+    assert add.__doc__ == "Returns the sum of two numbers."
+
+
+def test_log_function_missing_message_field_does_not_run_function(caplog):
+    calls = []
+
+    @log_function("Process {missing}")
+    def process(value):
+        calls.append(value)
+
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(KeyError, match="missing"):
+            process(5)
+
+    assert calls == []
+    assert caplog.messages == []


### PR DESCRIPTION
## What does this PR do?

Adds `easy_logging`, a small module that makes execution logging easier without filling application code with repeated logging calls and `try/except` blocks.

It provides two helpers, available directly from `py_simple`:

- **`log_step(message)`** — a context manager for logging individual code blocks.
- **`log_function(message_template)`** — a decorator for synchronous functions and methods, with messages built from positional, keyword, and default argument values.

Both log the start and successful completion at `INFO` level. When an operation fails, they log the exception with its traceback and re-raise it. The decorator also preserves the wrapped function’s metadata and return value.

```python
import logging
from py_simple import log_function, log_step

logging.basicConfig(level=logging.INFO)

with log_step("Calculate total"):
    total = sum([10, 20, 30])


@log_function("Add {a} and {b}")
def add(a: int, b: int = 10) -> int:
    return a + b


add(5)
```

The module uses Python’s standard `logging` configuration and introduces no additional dependencies.

## Type of change

- [x] New module (`easy_*.py`)
- [ ] New function(s) in an existing module
- [ ] Bug fix
- [x] Tests
- [x] Documentation (README, tutorial, docstrings)
- [ ] Infra / CI / tooling

## Before you submit

- [x] Public functions have docstrings following the project’s template, including both example tabs.
- [x] Tests were added for the new functionality.
- [x] I ran the existing test suite locally and it passes.
- [x] The new module has a module-level docstring, a tutorial page, and an entry in `mkdocs.yml`.
- [x] This makes a common task easier for beginners.

The eight new test cases pass locally. They cover successful execution, exception logging and propagation, argument formatting, metadata preservation, and missing template fields. Documentation includes docstrings, a short tutorial, and an API reference page, with both pages linked in the MkDocs navigation.

## Anything else the reviewer should know?

This implementation follows the approach described in my article, [How to Add Logging Without Cluttering Your Code](https://spaceshaman.github.io/posts/how-to-add-logging-without-cluttering-your-code/), which explains how context managers and decorators can keep detailed logging from obscuring application logic.

The decorator targets synchronous execution. It does not track the later execution of returned coroutines or generators.
